### PR TITLE
date input slash behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ All notable changes to this project will be documented in this file.
 ## [6.0.2](https://github.com/JudoPay/JudoKitObjC/releases/tag/6.0.2)
 TBA
 
+#### Changed
+- Injected card information is now shown with masking the card number.
+
 #### Fixed
 - An issue where deleting the slash in a date input field would result in unexpected behavior.
 - An issue where the sdk would assume a token payment when card details were be injected (eg. by card scanning).
+- An issue where injected card info would not appear correctly.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 ## [6.0.2](https://github.com/JudoPay/JudoKitObjC/releases/tag/6.0.2)
 TBA
 
+#### Added
+- UI Test for Maestro token payment.
+
 #### Changed
 - Injected card information is now shown with masking the card number.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,21 @@
 All notable changes to this project will be documented in this file.
 'judoKit' adheres to [Semantic Versioning](http://semver.org/).
 
-- `6.0.x` Releases - [6.0.0](#600) | [6.0.1](#601)
+- `6.0.x` Releases - [6.0.0](#600) | [6.0.1](#601) | [6.0.2](#602)
 - `5.x` Releases and below are related to the [judo-ObjC SDK](https://github.com/JudoPay/Judo-ObjC)
 
 
+## [6.0.2](https://github.com/JudoPay/JudoKitObjC/releases/tag/6.0.2)
+TBA
+
+#### Fixed
+- An issue where deleting the slash in a date input field would result in unexpected behavior.
+- An issue where the sdk would assume a token payment when card details were be injected (eg. by card scanning).
+
+---
+
 ## [6.0.1](https://github.com/JudoPay/JudoKitObjC/releases/tag/6.0.1)
-to be released on 2016-04-28
+Released on 2016-04-28
 
 #### Added
 - Added a method that recursively searches for the currently active and visible ViewController.

--- a/JudoKitObjCExampleAppUITests/JudoKitTokenPaymentTests.swift
+++ b/JudoKitObjCExampleAppUITests/JudoKitTokenPaymentTests.swift
@@ -79,4 +79,52 @@ class JudoKitTokenPaymentTests: XCTestCase {
         button.tap()
     }
     
+    func testMaestroTokenPayment() {
+        let app = XCUIApplication()
+        let tablesQuery = app.tables
+        tablesQuery.staticTexts["to be stored for future transactions"].tap()
+        
+        let elementsQuery = app.scrollViews.otherElements
+        elementsQuery.textFields["Card number"].typeText("6759000000005462")
+        
+        let startDateTextField = elementsQuery.textFields["Start date"]
+        startDateTextField.tap()
+        startDateTextField.typeText("0107")
+        
+        let expiryDateTextField = elementsQuery.textFields["Expiry date"]
+        expiryDateTextField.tap()
+        expiryDateTextField.typeText("1220")
+        
+        let cvvTextField = elementsQuery.textFields["CVV"]
+        cvvTextField.typeText("789")
+        
+        app.buttons["Add card"].tap()
+        
+        let tableQuery = tablesQuery.staticTexts["Token payment"]
+        let tableQueryExistsPredicate = NSPredicate(format: "exists == 1")
+        
+        expectationForPredicate(tableQueryExistsPredicate, evaluatedWithObject: tableQuery, handler: nil)
+        waitForExpectationsWithTimeout(15, handler: nil)
+        
+        tableQuery.tap()
+        
+        let startDateTextField2 = elementsQuery.textFields["Start date"]
+        startDateTextField2.tap()
+        startDateTextField2.typeText("0107")
+        
+        let cvvTextField2 = elementsQuery.textFields["CVV"]
+        cvvTextField2.tap()
+        cvvTextField2.typeText("789")
+        
+        app.childrenMatchingType(.Window).elementBoundByIndex(0).childrenMatchingType(.Other).element.childrenMatchingType(.Other).element.childrenMatchingType(.Other).element.buttons["Pay"].tap()
+        
+        let button = app.buttons["Home"]
+        let existsPredicate = NSPredicate(format: "exists == 1")
+        
+        expectationForPredicate(existsPredicate, evaluatedWithObject: button, handler: nil)
+        waitForExpectationsWithTimeout(195, handler: nil)
+        
+        button.tap()
+    }
+    
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Use our UI components for a seamless user experience for card data capture. Mini
 
 judoKit is a framework for integrating easy, fast and secure payments in your app with [judo](https://www.judopay.com/). It contains an exhaustive in-app payments and security toolkit that makes integration simple and quick.
 
+## Requirements
+
+This SDK requires Xcode 7.3 and Swift 2.2.
 
 ## Getting started
 

--- a/Source/Controller/JudoPayViewController.m
+++ b/Source/Controller/JudoPayViewController.m
@@ -62,6 +62,8 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     CGFloat _currentKeyboardHeight;
 }
 
+@property (nonatomic, readonly) BOOL isTokenPayment;
+
 @property (nonatomic, strong, readwrite) JPAmount *amount;
 @property (nonatomic, strong, readwrite) NSString *judoId;
 @property (nonatomic, strong, readwrite) JPReference *reference;
@@ -356,8 +358,8 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
         self.cardInputField.textField.text = formattedLastFour;
         self.expiryDateInputField.textField.text = formattedExpiryDate;
         [self updateInputFieldsWithNetwork:[self.cardDetails cardNetwork]];
-        self.securityCodeInputField.isTokenPayment = YES;
-        self.cardInputField.isTokenPayment = YES;
+        self.securityCodeInputField.isTokenPayment = self.isTokenPayment;
+        self.cardInputField.isTokenPayment = self.isTokenPayment;
         self.cardInputField.userInteractionEnabled = NO;
         self.expiryDateInputField.userInteractionEnabled = NO;
     }
@@ -558,6 +560,10 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 }
 
 #pragma mark - Lazy Loading
+
+- (BOOL)isTokenPayment {
+    return self.paymentToken;
+}
 
 - (UIScrollView *)contentView {
     if (!_contentView) {

--- a/Source/Controller/JudoPayViewController.m
+++ b/Source/Controller/JudoPayViewController.m
@@ -366,6 +366,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
         self.cardInputField.isTokenPayment = self.isTokenPayment;
         self.cardInputField.userInteractionEnabled = NO;
         self.expiryDateInputField.userInteractionEnabled = NO;
+        self.cardInputField.textField.secureTextEntry = NO;
     }
 }
 

--- a/Source/Controller/JudoPayViewController.m
+++ b/Source/Controller/JudoPayViewController.m
@@ -244,7 +244,11 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     [super viewDidAppear:animated];
     
     if (self.cardInputField.textField.text.length) {
-        [self.securityCodeInputField.textField becomeFirstResponder];
+        if (self.cardInputField.cardNetwork == CardNetworkMaestro) {
+            [self.startDateInputField.textField becomeFirstResponder];
+        } else {
+            [self.securityCodeInputField.textField becomeFirstResponder];
+        }
     } else {
         [self.cardInputField.textField becomeFirstResponder];
     }
@@ -411,7 +415,13 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
             startDate = self.startDateInputField.textField.text;
         }
         
-        JPCard *card = [[JPCard alloc] initWithCardNumber:[self.cardInputField.textField.text stringByReplacingOccurrencesOfString:@" " withString:@""]
+        NSString *cardNumberString = self.cardDetails.cardNumber;
+        
+        if (!cardNumberString) {
+            cardNumberString = [self.cardInputField.textField.text stringByReplacingOccurrencesOfString:@" " withString:@""];
+        }
+        
+        JPCard *card = [[JPCard alloc] initWithCardNumber:cardNumberString
                                                expiryDate:self.expiryDateInputField.textField.text
                                                secureCode:self.securityCodeInputField.textField.text];
         
@@ -776,7 +786,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 - (void)judoPayInputDidChangeText:(JPInputField *)input {
     [self showHintAfterDefaultDelay:input];
     BOOL allFieldsValid = NO;
-    allFieldsValid = self.cardInputField.isValid && self.expiryDateInputField.isValid && self.securityCodeInputField.isValid;
+    allFieldsValid = (self.cardDetails.cardNumber.isCardNumberValid || self.cardInputField.isValid) && self.expiryDateInputField.isValid && self.securityCodeInputField.isValid;
     if (self.theme.avsEnabled) {
         allFieldsValid = allFieldsValid && self.postCodeInputField.isValid && self.billingCountryInputField.isValid;
     }

--- a/Source/Model/JPCardDetails.m
+++ b/Source/Model/JPCardDetails.m
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 
 #import "JPCardDetails.h"
+#import "NSString+Card.h"
 
 @interface JPCardDetails ()
 
@@ -76,9 +77,18 @@
     [encoder encodeInt64:self.cardNetwork forKey:@"cardNetwork"];
 }
 
+- (CardNetwork)cardNetwork {
+    if (_cardNetwork == CardNetworkUnknown && self.cardNumber) {
+        _cardNetwork = self.cardNumber.cardNetwork;
+    }
+    return _cardNetwork;
+}
+
 - (nullable NSString *)formattedCardLastFour {
-    if (!self.cardLastFour) {
+    if (!self.cardLastFour && !self.cardNumber) {
         return nil;
+    } else if (self.cardNumber) {
+        self.cardLastFour = [self.cardNumber substringFromIndex:self.cardNumber.length - 4];
     }
     
     switch (self.cardNetwork) {

--- a/Source/View/InputFields/DateInputField.m
+++ b/Source/View/InputFields/DateInputField.m
@@ -57,19 +57,23 @@
         return [newString isEqualToString:@"0"] || [newString isEqualToString:@"1"];
     } else if (newString.length == 2) {
         
-        if (string.length == 0) {
-            return YES;
-        }
-        
-        if (!string.isNumeric) {
+        if (string.length != 0) {
+            if (string.length == 0) {
+                return YES;
+            }
+            
+            if (!string.isNumeric) {
+                return NO;
+            }
+            
+            if ([newString integerValue] <= 0 || [newString integerValue] > 12) {
+                return NO;
+            }
+            
+            self.textField.text = [newString stringByAppendingString:@"/"];
             return NO;
         }
-        
-        if ([newString integerValue] <= 0 || [newString integerValue] > 12) {
-            return NO;
-        }
-        
-        self.textField.text = [newString stringByAppendingString:@"/"];
+        self.textField.text = [newString substringToIndex:1];
         return NO;
         
     } else if (newString.length == 3) {


### PR DESCRIPTION
#### Added
 - UI Test for Maestro token payment.

#### Changed
- Injected card information is now shown with masking the card number.

#### Fixed
- An issue where deleting the slash in a date input field would result in unexpected behavior.
- An issue where the sdk would assume a token payment when card details were be injected (eg. by card scanning).
- An issue where injected card info would not appear correctly.
