### PR TITLE
Apple Pay Integration [JudoKit Invoker]

### DIFF
--- a/JudoKitObjC.xcodeproj/project.pbxproj
+++ b/JudoKitObjC.xcodeproj/project.pbxproj
@@ -31,16 +31,18 @@
 		15CFC9EE1FB74B0C00430D31 /* VCOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CFC9EC1FB74A4200430D31 /* VCOTests.swift */; };
 		15CFC9EF1FB759B300430D31 /* JPVCOResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 15CFC9E81FB7371300430D31 /* JPVCOResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		30673FFC22F42EA500417C85 /* JPConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 30673FFB22F42EA500417C85 /* JPConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		30D1851F2301ADEB0097F85F /* ContactInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D185122301ADEB0097F85F /* ContactInformation.h */; };
+		30D1851F2301ADEB0097F85F /* ContactInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D185122301ADEB0097F85F /* ContactInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		30D185202301ADEB0097F85F /* PostalAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D1851A2301ADEB0097F85F /* PostalAddress.m */; };
-		30D185212301ADEB0097F85F /* PostalAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D1851B2301ADEB0097F85F /* PostalAddress.h */; };
-		30D185222301ADEB0097F85F /* ApplePayWrappers.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D1851C2301ADEB0097F85F /* ApplePayWrappers.h */; };
+		30D185212301ADEB0097F85F /* PostalAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D1851B2301ADEB0097F85F /* PostalAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		30D185222301ADEB0097F85F /* ApplePayWrappers.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D1851C2301ADEB0097F85F /* ApplePayWrappers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		30D185232301ADEB0097F85F /* ContactInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D1851D2301ADEB0097F85F /* ContactInformation.m */; };
 		30D185242301ADEB0097F85F /* ApplePayWrappers.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D1851E2301ADEB0097F85F /* ApplePayWrappers.m */; };
-		30D185322301AFC50097F85F /* ApplePayConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D185292301AFC50097F85F /* ApplePayConfiguration.h */; };
+		30D185322301AFC50097F85F /* ApplePayConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D185292301AFC50097F85F /* ApplePayConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		30D185332301AFC50097F85F /* ApplePayConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D185312301AFC50097F85F /* ApplePayConfiguration.m */; };
 		30D185372301AFD90097F85F /* ApplePayManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D185352301AFD90097F85F /* ApplePayManager.m */; };
-		30D185382301AFD90097F85F /* ApplePayManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D185362301AFD90097F85F /* ApplePayManager.h */; };
+		30D185382301AFD90097F85F /* ApplePayManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D185362301AFD90097F85F /* ApplePayManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		30D185472301B2940097F85F /* MockJPTransactionData.json in Resources */ = {isa = PBXBuildFile; fileRef = 30D1853F2301B2940097F85F /* MockJPTransactionData.json */; };
+		30D185542301B4A90097F85F /* ApplePayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D185522301B3FD0097F85F /* ApplePayTests.swift */; };
 		3B35F6401C98626400DBAF59 /* DetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3B35F63F1C98626400DBAF59 /* DetailViewController.xib */; };
 		3B4EB3911C981511006265A0 /* UIColor+Judo.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B4EB38F1C981511006265A0 /* UIColor+Judo.h */; };
 		3B4EB3921C981511006265A0 /* UIColor+Judo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B4EB3901C981511006265A0 /* UIColor+Judo.m */; };
@@ -342,6 +344,8 @@
 		30D185312301AFC50097F85F /* ApplePayConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ApplePayConfiguration.m; sourceTree = "<group>"; };
 		30D185352301AFD90097F85F /* ApplePayManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ApplePayManager.m; sourceTree = "<group>"; };
 		30D185362301AFD90097F85F /* ApplePayManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePayManager.h; sourceTree = "<group>"; };
+		30D1853F2301B2940097F85F /* MockJPTransactionData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MockJPTransactionData.json; sourceTree = "<group>"; };
+		30D185522301B3FD0097F85F /* ApplePayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplePayTests.swift; sourceTree = "<group>"; };
 		3B35F63F1C98626400DBAF59 /* DetailViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DetailViewController.xib; sourceTree = "<group>"; };
 		3B4EB38F1C981511006265A0 /* UIColor+Judo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIColor+Judo.h"; path = "Extensions/UIColor+Judo.h"; sourceTree = "<group>"; };
 		3B4EB3901C981511006265A0 /* UIColor+Judo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+Judo.m"; path = "Extensions/UIColor+Judo.m"; sourceTree = "<group>"; };
@@ -725,6 +729,7 @@
 				3B678BC71C735AB80001DC2F /* JudoKit.h */,
 				3B678BC81C735AB80001DC2F /* JudoKit.m */,
 				30673FFB22F42EA500417C85 /* JPConstants.h */,
+				30D1853F2301B2940097F85F /* MockJPTransactionData.json */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -876,6 +881,7 @@
 		3B9711831C7618C000E9A347 /* APITests */ = {
 			isa = PBXGroup;
 			children = (
+				30D185522301B3FD0097F85F /* ApplePayTests.swift */,
 				3B4EB3E51C982A25006265A0 /* AuthenticationTests.swift */,
 				3B4EB3E61C982A25006265A0 /* CollectionTests.swift */,
 				3BFD9A981CDA008E00B8385D /* DedupTestCase.swift */,
@@ -1230,6 +1236,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				30D185472301B2940097F85F /* MockJPTransactionData.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1383,6 +1390,7 @@
 				702804361CE9C96D00150B21 /* CardDetailsSetTests.swift in Sources */,
 				3B4EB4011C982A25006265A0 /* TransactionTests.swift in Sources */,
 				3B4EB3FA1C982A25006265A0 /* PreAuthTests.swift in Sources */,
+				30D185542301B4A90097F85F /* ApplePayTests.swift in Sources */,
 				3B4EB3F51C982A25006265A0 /* CollectionTests.swift in Sources */,
 				3B4EB3F71C982A25006265A0 /* JudoTests.swift in Sources */,
 				3B4EB3FC1C982A25006265A0 /* RefundTests.swift in Sources */,

--- a/JudoKitObjCExampleApp/DetailViewController.h
+++ b/JudoKitObjCExampleApp/DetailViewController.h
@@ -25,9 +25,12 @@
 #import <UIKit/UIKit.h>
 
 @class JPTransactionData;
+@class ContactInformation;
 
 @interface DetailViewController : UIViewController
 
 @property (nonatomic, strong) JPTransactionData *transactionData;
+@property (nonatomic, strong) ContactInformation *_Nullable billingInformation;
+@property (nonatomic, strong) ContactInformation *_Nullable shippingInformation;
 
 @end

--- a/JudoKitObjCExampleApp/DetailViewController.m
+++ b/JudoKitObjCExampleApp/DetailViewController.m
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 
 #import "DetailViewController.h"
+#import "ContactInformation.h"
 
 @import JudoKitObjC;
 
@@ -31,6 +32,10 @@
 @property (nonatomic, strong) IBOutlet UILabel *dateStampLabel;
 @property (nonatomic, strong) IBOutlet UILabel *amountLabel;
 @property (weak, nonatomic) IBOutlet UILabel *resolutionLabel;
+@property (weak, nonatomic) IBOutlet UIStackView *billingAddressStackView;
+@property (weak, nonatomic) IBOutlet UIStackView *shippingAddressStackView;
+@property (weak, nonatomic) IBOutlet UILabel *billingAddressLabel;
+@property (weak, nonatomic) IBOutlet UILabel *shippingAddressLabel;
 
 @property (nonatomic, strong) NSDateFormatter *inputDateFormatter;
 @property (nonatomic, strong) NSDateFormatter *outputDateFormatter;
@@ -55,6 +60,17 @@
         self.amountLabel.text = self.transactionData.amount.amount;
         self.resolutionLabel.text = self.transactionData.message;
     }
+    
+    if (self.billingInformation) {
+        [self.billingAddressStackView setHidden:NO];
+        self.billingAddressLabel.text = self.billingInformation.toString;
+    }
+    
+    if (self.shippingInformation) {
+        [self.shippingAddressStackView setHidden:NO];
+        self.shippingAddressLabel.text = self.shippingInformation.toString;
+    }
+    
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/JudoKitObjCExampleApp/DetailViewController.xib
+++ b/JudoKitObjCExampleApp/DetailViewController.xib
@@ -1,19 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="DetailViewController">
             <connections>
                 <outlet property="amountLabel" destination="cKN-1i-b7O" id="o6t-m3-VQX"/>
+                <outlet property="billingAddressLabel" destination="Nw1-B8-Hq8" id="YlU-5j-XkK"/>
+                <outlet property="billingAddressStackView" destination="Zag-7G-Mud" id="N4U-6h-Qov"/>
                 <outlet property="dateStampLabel" destination="lji-4S-hTK" id="cic-vh-LYR"/>
                 <outlet property="resolutionLabel" destination="SAh-Vf-TSG" id="vFO-l4-K9r"/>
+                <outlet property="shippingAddressLabel" destination="Y83-Ah-Gmn" id="aO1-en-vZY"/>
+                <outlet property="shippingAddressStackView" destination="OHv-6a-tug" id="E4H-D5-adE"/>
                 <outlet property="view" destination="iN0-l3-epB" id="qaU-qq-IPz"/>
             </connections>
         </placeholder>
@@ -22,129 +26,185 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NGd-iX-WMf">
-                    <rect key="frame" x="20" y="165" width="335" height="1"/>
-                    <color key="backgroundColor" red="0.50980392159999999" green="0.50980392159999999" blue="0.50980392159999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="lJE-SX-tPC"/>
-                    </constraints>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aI8-bN-hFZ">
-                    <rect key="frame" x="20" y="119" width="335" height="1"/>
-                    <color key="backgroundColor" red="0.50980392159999999" green="0.50980392159999999" blue="0.50980392159999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="Men-rB-N8u"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2015-02-17, 13:21" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lji-4S-hTK">
-                    <rect key="frame" x="217" y="86" width="138" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.25 GBP" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cKN-1i-b7O">
-                    <rect key="frame" x="285" y="132" width="70" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Amount" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K72-mG-57I">
-                    <rect key="frame" x="20" y="132" width="60" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Success" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SAh-Vf-TSG">
-                    <rect key="frame" x="148" y="182" width="207" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Resolution" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zW0-0Q-9hG">
-                    <rect key="frame" x="20" y="182" width="81" height="21"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="81" id="oka-m4-iRM"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YXd-ER-n1p">
-                    <rect key="frame" x="20" y="86" width="36" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="I1W-53-pHs">
+                    <rect key="frame" x="10" y="100" width="355" height="233"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="hOF-mc-d1O">
+                            <rect key="frame" x="0.0" y="0.0" width="355" height="125.5"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="H6T-s6-pyl">
+                                    <rect key="frame" x="0.0" y="0.0" width="355" height="32.5"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="161" translatesAutoresizingMaskIntoConstraints="NO" id="Rhi-MM-HNw">
+                                            <rect key="frame" x="0.0" y="0.0" width="355" height="20.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YXd-ER-n1p">
+                                                    <rect key="frame" x="0.0" y="0.0" width="56.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2015-02-17, 13:21" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lji-4S-hTK">
+                                                    <rect key="frame" x="217.5" y="0.0" width="137.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aI8-bN-hFZ">
+                                            <rect key="frame" x="0.0" y="31.5" width="355" height="1"/>
+                                            <color key="backgroundColor" red="0.84329800130172095" green="0.84329800130172095" blue="0.84329800130172095" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="Men-rB-N8u"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="5KD-SI-0RT">
+                                    <rect key="frame" x="0.0" y="46.5" width="355" height="32.5"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="205" translatesAutoresizingMaskIntoConstraints="NO" id="vDY-3b-ej8">
+                                            <rect key="frame" x="0.0" y="0.0" width="355" height="20.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="Amount" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K72-mG-57I">
+                                                    <rect key="frame" x="0.0" y="0.0" width="80.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.25 GBP" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cKN-1i-b7O">
+                                                    <rect key="frame" x="285.5" y="0.0" width="69.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NGd-iX-WMf">
+                                            <rect key="frame" x="0.0" y="31.5" width="355" height="1"/>
+                                            <color key="backgroundColor" red="0.84329800129999999" green="0.84329800129999999" blue="0.84329800129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="lJE-SX-tPC"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="EDX-cH-CLa">
+                                    <rect key="frame" x="0.0" y="93" width="355" height="32.5"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="47" translatesAutoresizingMaskIntoConstraints="NO" id="ZhO-bW-Dpd">
+                                            <rect key="frame" x="0.0" y="0.0" width="355" height="20.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Resolution" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zW0-0Q-9hG">
+                                                    <rect key="frame" x="0.0" y="0.0" width="243.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Success" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SAh-Vf-TSG">
+                                                    <rect key="frame" x="290.5" y="0.0" width="64.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9lb-My-FVs">
+                                            <rect key="frame" x="0.0" y="31.5" width="355" height="1"/>
+                                            <color key="backgroundColor" red="0.84329800129999999" green="0.84329800129999999" blue="0.84329800129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="Yna-7M-ih0"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="Zag-7G-Mud">
+                                    <rect key="frame" x="0.0" y="125.5" width="355" height="22"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GEc-Jc-KO6">
+                                            <rect key="frame" x="0.0" y="0.0" width="355" height="10"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Billing Address" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vx1-5N-yGs">
+                                                    <rect key="frame" x="0.0" y="0.0" width="119" height="0.0"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nw1-B8-Hq8">
+                                                    <rect key="frame" x="0.0" y="10" width="28.5" height="0.0"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ayu-PQ-smv">
+                                            <rect key="frame" x="0.0" y="21" width="355" height="1"/>
+                                            <color key="backgroundColor" red="0.84329800129999999" green="0.84329800129999999" blue="0.84329800129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="RlO-Df-VU7"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="OHv-6a-tug">
+                                    <rect key="frame" x="0.0" y="125.5" width="355" height="22"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="6oP-Ek-Bf2">
+                                            <rect key="frame" x="0.0" y="0.0" width="355" height="10"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shipping Address" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2GB-uz-Cdv">
+                                                    <rect key="frame" x="0.0" y="0.0" width="141" height="0.0"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y83-Ah-Gmn">
+                                                    <rect key="frame" x="0.0" y="10" width="28.5" height="0.0"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8R5-fL-mdB">
+                                            <rect key="frame" x="0.0" y="21" width="355" height="1"/>
+                                            <color key="backgroundColor" red="0.84329800129999999" green="0.84329800129999999" blue="0.84329800129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="XMc-da-Vop"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                        </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zfi-un-lBD">
+                            <rect key="frame" x="0.0" y="175.5" width="355" height="57.5"/>
+                            <string key="text">This is a receipt example showing only the createdAt, amount and currency properties of the receipt object. Please refer to our API Reference Documentation for all the properties you can display.</string>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <color key="textColor" red="0.50980392159999999" green="0.50980392159999999" blue="0.50980392159999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WWu-ea-bHu">
-                    <rect key="frame" x="167" y="629" width="41" height="30"/>
+                    <rect key="frame" x="167" y="617" width="41" height="30"/>
                     <state key="normal" title="Home"/>
                     <connections>
                         <action selector="homeButtonHandler:" destination="-1" eventType="touchUpInside" id="H0x-o2-OeR"/>
                     </connections>
                 </button>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9lb-My-FVs">
-                    <rect key="frame" x="16" y="214" width="335" height="1"/>
-                    <color key="backgroundColor" red="0.50980392159999999" green="0.50980392159999999" blue="0.50980392159999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="Yna-7M-ih0"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zfi-un-lBD">
-                    <rect key="frame" x="16" y="223.5" width="335" height="57.5"/>
-                    <string key="text">This is a receipt example showing only the createdAt, amount and currency properties of the receipt object. Please refer to our API Reference Documentation for all the properties you can display.</string>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <color key="textColor" red="0.50980392159999999" green="0.50980392159999999" blue="0.50980392159999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
             </subviews>
             <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="9lb-My-FVs" secondAttribute="trailing" constant="24" id="1Ar-LK-Fvq"/>
-                <constraint firstItem="lji-4S-hTK" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="86" id="3GS-1V-Bg2">
-                    <variation key="widthClass=compact" constant="86"/>
-                </constraint>
-                <constraint firstAttribute="trailing" secondItem="zfi-un-lBD" secondAttribute="trailing" constant="24" id="3V1-xM-ODk"/>
-                <constraint firstItem="K72-mG-57I" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="5EI-DK-OKk"/>
-                <constraint firstItem="SAh-Vf-TSG" firstAttribute="leading" secondItem="zW0-0Q-9hG" secondAttribute="trailing" constant="47" id="6Ht-47-R1R"/>
-                <constraint firstItem="cKN-1i-b7O" firstAttribute="centerY" secondItem="K72-mG-57I" secondAttribute="centerY" id="9ET-QJ-4Dn"/>
-                <constraint firstItem="9lb-My-FVs" firstAttribute="top" secondItem="zW0-0Q-9hG" secondAttribute="bottom" constant="11" id="CEG-Qd-Vhf"/>
-                <constraint firstItem="cKN-1i-b7O" firstAttribute="top" secondItem="aI8-bN-hFZ" secondAttribute="bottom" constant="12" id="Cro-aU-HIZ"/>
-                <constraint firstItem="aI8-bN-hFZ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="D0F-rc-Wsr"/>
-                <constraint firstItem="YXd-ER-n1p" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="GSC-0G-xQs"/>
-                <constraint firstAttribute="trailing" secondItem="lji-4S-hTK" secondAttribute="trailing" constant="20" id="IiN-GN-WsG"/>
-                <constraint firstAttribute="trailing" secondItem="SAh-Vf-TSG" secondAttribute="trailing" constant="20" id="JT5-Rb-bMy"/>
-                <constraint firstAttribute="bottom" secondItem="zfi-un-lBD" secondAttribute="bottom" constant="386" id="JwG-q2-eQH"/>
-                <constraint firstItem="YXd-ER-n1p" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="86" id="KCh-gb-EwX">
-                    <variation key="widthClass=compact" constant="86"/>
-                </constraint>
-                <constraint firstAttribute="trailing" secondItem="aI8-bN-hFZ" secondAttribute="trailing" constant="20" id="KDS-JZ-Mxz"/>
-                <constraint firstItem="SAh-Vf-TSG" firstAttribute="baseline" secondItem="zW0-0Q-9hG" secondAttribute="baseline" id="KX1-fU-2UJ"/>
-                <constraint firstItem="K72-mG-57I" firstAttribute="top" secondItem="aI8-bN-hFZ" secondAttribute="bottom" constant="8" id="Q18-wq-eBQ"/>
-                <constraint firstAttribute="trailing" secondItem="NGd-iX-WMf" secondAttribute="trailing" constant="20" id="SaI-fB-fpC"/>
-                <constraint firstItem="lji-4S-hTK" firstAttribute="centerY" secondItem="YXd-ER-n1p" secondAttribute="centerY" id="V4Q-qC-pHH"/>
-                <constraint firstAttribute="bottom" secondItem="WWu-ea-bHu" secondAttribute="bottom" constant="8" id="YZU-eb-eay"/>
-                <constraint firstItem="aI8-bN-hFZ" firstAttribute="top" secondItem="lji-4S-hTK" secondAttribute="bottom" constant="12" id="b0A-3K-uGY"/>
-                <constraint firstItem="zW0-0Q-9hG" firstAttribute="top" secondItem="NGd-iX-WMf" secondAttribute="bottom" constant="16" id="cQi-87-mLC"/>
-                <constraint firstItem="zW0-0Q-9hG" firstAttribute="leading" secondItem="NGd-iX-WMf" secondAttribute="leading" id="gik-u5-9ne"/>
-                <constraint firstItem="NGd-iX-WMf" firstAttribute="top" secondItem="cKN-1i-b7O" secondAttribute="bottom" constant="12" id="msa-Nx-9Lp"/>
+                <constraint firstAttribute="bottom" secondItem="WWu-ea-bHu" secondAttribute="bottom" constant="20" id="ESW-nc-4EY"/>
+                <constraint firstItem="I1W-53-pHs" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="100" id="P4b-CX-sOy"/>
+                <constraint firstItem="I1W-53-pHs" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="Wg7-pi-HYK"/>
+                <constraint firstAttribute="trailing" secondItem="I1W-53-pHs" secondAttribute="trailing" constant="10" id="dg7-sT-C0C"/>
                 <constraint firstItem="WWu-ea-bHu" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="qfy-my-77v"/>
-                <constraint firstAttribute="trailing" secondItem="cKN-1i-b7O" secondAttribute="trailing" constant="20" id="qmP-Rc-Gtm"/>
-                <constraint firstItem="9lb-My-FVs" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="rSh-yF-QNZ"/>
-                <constraint firstItem="zfi-un-lBD" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="tRW-Dh-dT3"/>
-                <constraint firstItem="NGd-iX-WMf" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="uPs-gK-XwO"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="9ET-QJ-4Dn"/>
-                </mask>
-            </variation>
-            <variation key="widthClass=compact">
-                <mask key="constraints">
-                    <exclude reference="Q18-wq-eBQ"/>
-                    <include reference="9ET-QJ-4Dn"/>
-                </mask>
-            </variation>
             <point key="canvasLocation" x="33.5" y="53.5"/>
         </view>
     </objects>

--- a/JudoKitObjCExampleApp/ExampleAppCredentials.h
+++ b/JudoKitObjCExampleApp/ExampleAppCredentials.h
@@ -29,6 +29,7 @@
 static NSString * const judoId  = @"<#YOUR JUDOID#>";
 static NSString * const token   = @"<#YOUR TOKEN#>";
 static NSString * const secret  = @"<#YOUR SECRET#>";
+static NSString * const merchantId  = @"<#YOUR MERCHANT ID#>";
 
 @interface ExampleAppCredentials : NSObject
 

--- a/Source/ApplePayManager.h
+++ b/Source/ApplePayManager.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  * the ApplePay payment sheet. It is initialized from a PKPaymentRequest item that was
  * created based on the parameters passed by ApplePayConfiguration.
  */
-- (PKPaymentAuthorizationViewController *)pkPaymentAuthorizationViewController;
+- (nullable PKPaymentAuthorizationViewController *)pkPaymentAuthorizationViewController;
 
 @end
 

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <PassKit/PassKit.h>
 
 #import "JPSession.h"
 #import "JPTransactionData.h"
@@ -32,6 +33,7 @@
 static NSString *__nonnull const JudoKitVersion = @"7.1.0";
 
 @class JudoPayViewController;
+@class ApplePayConfiguration;
 
 @class JPPayment, JPPreAuth, JPRegisterCard, JPSaveCard, JPTransaction;
 @class JPCollection, JPVoid, JPRefund;
@@ -434,3 +436,21 @@ static NSString *__nonnull const JudoKitVersion = @"7.1.0";
                 completion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
 
 @end
+
+
+@interface JudoKit (ApplePay) <PKPaymentAuthorizationViewControllerDelegate>
+
+/**
+ *  This method will request and process Apple Pay payments. It works by presenting the
+ *  PKAuthorizationViewController object and using its delegate methods to send a JPTransaction object
+ *  and return the payment completion block. Besides the usual response, JPResponse also stores the
+ *  optional billing and shipping contact information.
+ *
+ *  @param configuration    An ApplePayConfiguration object that sets Apple Pay payment properties.
+ *  @param completion       The completion handler which will respond with a JPResponse object or an NSError.
+ */
+- (void)invokeApplePayWithConfiguration:(nonnull ApplePayConfiguration *)configuration
+                             completion:(nonnull JudoCompletionBlock)completion;
+
+@end
+

--- a/Source/JudoKitObjC.h
+++ b/Source/JudoKitObjC.h
@@ -30,6 +30,8 @@ FOUNDATION_EXPORT double JudoKitObjCVersionNumber;
 //! Project version string for JudoKitObjC.
 FOUNDATION_EXPORT const unsigned char JudoKitObjCVersionString[];
 
+#import <JudoKitObjC/ApplePayConfiguration.h>
+#import <JudoKitObjC/ApplePayManager.h>
 #import <JudoKitObjC/CardInputField.h>
 #import <JudoKitObjC/CardLogoView.h>
 #import <JudoKitObjC/JPAddress.h>

--- a/Source/MockJPTransactionData.json
+++ b/Source/MockJPTransactionData.json
@@ -1,0 +1,26 @@
+{
+    "receiptId": "29402815",
+    "yourPaymentReference": "10360",
+    "type": "Payment",
+    "createdAt": "2019-10-08T07:29:55.850Z",
+    "result": "Success",
+    "message": "Operation succesful!",
+    "judoId": "9911991199",
+    "merchantName": "Tim Apple",
+    "appearsOnStatementAs": "Tim Apple Jr.",
+    "currency": "GBP",
+    "originalAmount": "0.3",
+    "netAmount": "0.3",
+    "amount": "0.3",
+    "cardDetails": {
+        "cardLastFour": "1324",
+        "endDate": "12/20",
+        "cardToken": "200420042004",
+        "cardNumber": "400012345678",
+        "cardType": "1"
+    },
+    "consumer": {
+        "yourConsumerReference": "12345678",
+        "consumerToken": "12345678"
+    }
+}

--- a/Source/Model/JPResponse.h
+++ b/Source/Model/JPResponse.h
@@ -26,6 +26,7 @@
 
 @class JPPagination;
 @class JPTransactionData;
+@class ContactInformation;
 
 /**
  *   Response object is created out of the JSON response of the judo API for seamless handling of values returned in any call. The response object can hold multiple transaction objects and supports pagination if available. In most cases (successful Payment, Pre-auth, RegisterCard or SaveCard operation) a Response object will hold one TransactionData object. Supporting CollectionType protocol, you can access the elements by subscripting `let transactionData = response[0]` or using the available variable `response.first` as a more readable approach.
@@ -41,6 +42,16 @@
  *  The current pagination response
  */
 @property (nonatomic, strong) JPPagination *_Nullable pagination;
+
+/**
+ * Billing contact information returned from ApplePay
+ */
+@property (nonatomic, strong) ContactInformation *_Nullable billingInfo;
+
+/**
+ * Shipping contact information returned from ApplePay
+ */
+@property (nonatomic, strong) ContactInformation *_Nullable shippingInfo;
 
 /**
  *  Initialize a Response object with pagination if available

--- a/Tests/APITests/ApplePayTests.swift
+++ b/Tests/APITests/ApplePayTests.swift
@@ -1,0 +1,191 @@
+//
+//  ApplePayTests.swift
+//
+//  Copyright (c) 2019 Alternative Payments Ltd
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+
+@testable import JudoKitObjC
+
+class ApplePayTests: JudoTestCase {
+    
+    var configuration: ApplePayConfiguration!
+    var manager: ApplePayManager!
+    
+    override func setUp() {
+        super.setUp()
+        
+        let items = [
+            PaymentSummaryItem(label: "Item 1", amount: NSDecimalNumber(string: "0.01")),
+            PaymentSummaryItem(label: "Item 2", amount: NSDecimalNumber(string: "0.02")),
+            PaymentSummaryItem(label: "Tim Apple", amount: NSDecimalNumber(string: "0.03"))
+        ]
+        
+        configuration = ApplePayConfiguration(judoId: myJudoId,
+                                              reference: "consumer reference",
+                                              merchantId: "",
+                                              currency: "GBP",
+                                              countryCode: "GB",
+                                              paymentSummaryItems: items)
+        
+        manager = ApplePayManager(configuration: configuration)
+    }
+    
+    override func tearDown() {
+        manager = nil
+        configuration = nil
+        
+        super.tearDown()
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized
+     *
+     *  THEN:  default values for merchant capabilities, supported card networks, transaction type,
+     *         shipping type and returned contact info must be set.
+     */
+    func test_OnApplePayConfigurationInitialization_DefaultValuesAreRespected() {
+        XCTAssertEqual(configuration.merchantCapabilities, MerchantCapability.capability3DS,
+                       "Configuration's merchantCapabilities does not default to 3D Security")
+        XCTAssertTrue(configuration.supportedCardNetworks.contains(NSNumber(value: CardNetwork.visa.rawValue)),
+                       "Configuration's supportedCardNetworks does not contain Visa")
+        XCTAssertTrue(configuration.supportedCardNetworks.contains(NSNumber(value: CardNetwork.AMEX.rawValue)),
+                      "Configuration's supportedCardNetworks does not contain AmEx")
+        XCTAssertTrue(configuration.supportedCardNetworks.contains(NSNumber(value: CardNetwork.masterCard.rawValue)),
+                      "Configuration's supportedCardNetworks does not contain MasterCard")
+
+        if #available(iOS 12.0, *) {
+            XCTAssertTrue(configuration.supportedCardNetworks.contains(NSNumber(value: CardNetwork.maestro.rawValue)),
+                          "Configuration's supportedCardNetworks does not contain Maestro")
+        }
+        
+        XCTAssertEqual(configuration.transactionType, TransactionType.payment,
+                       "Configuration's transactionType does not default to Payment")
+        XCTAssertEqual(configuration.shippingType, PaymentShippingType.ShippingTypeShipping,
+                       "Configuration's shippingType does not default to Shipping")
+        XCTAssertEqual(configuration.returnedContactInfo, ReturnedInfo.billingContacts,
+                       "Configuration's returnedContactInfo does not default to Billing")
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized correctly
+     *
+     *  THEN:  ApplePayManager should return a PKAuthorizationViewController object when calling
+     *         its "pkPaymentAuthorizationViewController" instance method
+     */
+    func test_OnValidConfiguration_ManagerReturnsValidPKAuthorizationViewController() {
+        XCTAssertNotNil(manager.pkPaymentAuthorizationViewController(),
+                        "PKPaymentAuthorizationViewController must be initialized on valid configuration")
+        XCTAssertTrue(manager.pkPaymentAuthorizationViewController()!.isKind(of: PKPaymentAuthorizationViewController.self),
+                      "Returned controller must be of type PKPaymentAuthorizationViewController")
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized incorrectly
+     *
+     *  THEN:  ApplePayManager should return nil when calling
+     *         its "pkPaymentAuthorizationViewController" instance method
+     */
+    func test_OnInvalidConfiguration_ManagerReturnsNilPKAuthorizationViewController() {
+        configuration.paymentSummaryItems = [];
+        XCTAssertNil(manager.pkPaymentAuthorizationViewController(),
+                    "PKPaymentAuthorizationViewController must be nil on invalid configuration")
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized correctly
+     *
+     *  THEN:  ApplePayManager should return a valid JPAmount object when calling
+     *         its "jpAmount" instance method
+     */
+    func test_OnValidConfiguration_ManagerGeneratesCorrectJPAmount() {
+        XCTAssertNotNil(manager.jpAmount(),
+                        "JPAmount must not be nil on correct configuration")
+        XCTAssertEqual(manager.jpAmount().amount, "0.03",
+                       "JPAmount does not display the correct amount")
+        XCTAssertEqual(manager.jpAmount().currency, "GBP",
+                       "JPAmount does not display the correct currency")
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized incorrectly
+     *
+     *  THEN:  ApplePayManager should return a JPAmount object with empty amount
+     *         when calling its "jpAmount" instance method
+     */
+    func test_OnInvalidConfiguration_ManagerGeneratesEmptyJPAmount() {
+        configuration = ApplePayConfiguration()
+        manager = ApplePayManager(configuration: configuration)
+        XCTAssertEqual(manager.jpAmount().amount, "",
+                        "JPAmount must have empty on incorrect configuration")
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized correctly
+     *
+     *  THEN:  ApplePayManager should return a valid JPReference object when calling
+     *         its "jpReference" instance method
+     */
+    func test_OnValidConfiguration_ManagerGeneratesCorrectJPReference() {
+        XCTAssertEqual(manager.jpReference().consumerReference, "consumer reference",
+                       "JPReference's consumerReference must match the one specified")
+    }
+    
+    /**
+     * GIVEN:  ApplePayConfiguration is initialized incorrectly
+     *
+     *  THEN:  ApplePayManager should return a JPReference object with empty consumerReference when
+     *         calling its "jpReference" instance method
+     */
+    func test_OnInvalidConfiguration_ManagerGeneratesCorrectJPReference() {
+        configuration = ApplePayConfiguration()
+        manager = ApplePayManager(configuration: configuration)
+        XCTAssertEqual(manager.jpReference().consumerReference, "",
+                       "JPReference must have empty consumerReference on incorrect configuration")
+    }
+    
+    /**
+     * GIVEN:  ApplePayManager wants to convert a valid PKContact to ContactInformation
+     *
+     *  THEN:  a ContactInformation object is returned with all PKContact properties set
+     */
+    func test_OnConversionFromPKContact_ReturnValidContactInformation() {
+        
+        var name = PersonNameComponents()
+        name.givenName = "Tim"
+        name.familyName = "Apple"
+        
+        let pkContact = PKContact();
+        pkContact.name = name;
+        pkContact.emailAddress = "tim.apple@email.com"
+        
+        let information = manager.contactInformation(fromPaymentContact: pkContact)
+        XCTAssertNotNil(information, "ContactInformation must not be nil")
+        
+        XCTAssertEqual(information?.name?.givenName, "Tim",
+                       "Given name does not match the one specified in the PKContact object")
+        XCTAssertEqual(information?.name?.familyName, "Apple",
+                       "Family name does not match the one specified in the PKContact object")
+        XCTAssertEqual(information?.emailAddress, "tim.apple@email.com",
+                       "Email does not match the one specified in the PKContact object")
+    }
+}
+


### PR DESCRIPTION
- Added method to the JudoAPI to invoke ApplePay payments;
- Added two new properties to the JPResponse object to save billing/shipping addresses;

**NOTE:**
For demo purposes, the JPResponse object has been mocked and the whole response/error logic has been skipped entirely. This is done to showcase that we successfully obtain the billing/shipping information, presenting it into the payment summary screen;