### PR TITLE
[Unit Test Improvement & Fixes] Recept, Refund & Register Card

### DIFF
--- a/JudoKitObjC.xcodeproj/xcshareddata/xcschemes/JudoKitObjC.xcscheme
+++ b/JudoKitObjC.xcodeproj/xcshareddata/xcschemes/JudoKitObjC.xcscheme
@@ -38,38 +38,6 @@
                BlueprintName = "JudoKitObjCTests"
                ReferencedContainer = "container:JudoKitObjC.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "ListTests">
-               </Test>
-               <Test
-                  Identifier = "ReceiptTests">
-               </Test>
-               <Test
-                  Identifier = "RefundTests">
-               </Test>
-               <Test
-                  Identifier = "SaveCardTests">
-               </Test>
-               <Test
-                  Identifier = "TokenPaymentTests">
-               </Test>
-               <Test
-                  Identifier = "TokenPreAuthTests">
-               </Test>
-               <Test
-                  Identifier = "TransactionEnricherTests">
-               </Test>
-               <Test
-                  Identifier = "TransactionTests">
-               </Test>
-               <Test
-                  Identifier = "VCOTests">
-               </Test>
-               <Test
-                  Identifier = "VoidTransactionTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/JudoKitObjC.xcodeproj/xcshareddata/xcschemes/JudoKitObjC.xcscheme
+++ b/JudoKitObjC.xcodeproj/xcshareddata/xcschemes/JudoKitObjC.xcscheme
@@ -49,9 +49,6 @@
                   Identifier = "RefundTests">
                </Test>
                <Test
-                  Identifier = "RegisterCardTests">
-               </Test>
-               <Test
                   Identifier = "SaveCardTests">
                </Test>
                <Test

--- a/Source/ApplePayManager.m
+++ b/Source/ApplePayManager.m
@@ -167,46 +167,46 @@
 
 #pragma mark - Conversions to PassKit objects
 
-- (nullable PKPaymentNetwork)pkPaymentNetworkForCardNetwork:(CardNetwork)cardNetwork {
+- (nullable PKPaymentNetwork)pkPaymentNetworkForCardNetwork:(CardNetwork)cardNetwork { //!OCLINT
 
     switch (cardNetwork) {
-            
+
         case CardNetworkAMEX:
             return PKPaymentNetworkAmex;
-            
+
         case CardNetworkCarteBancaire:
             return PKPaymentNetworkCarteBancaire;
-            
+
         case CardNetworkChinaUnionPay:
             return PKPaymentNetworkChinaUnionPay;
-            
+
         case CardNetworkDiscover:
             return PKPaymentNetworkDiscover;
-            
+
         case CardNetworkJCB:
             return PKPaymentNetworkJCB;
-            
+
         case CardNetworkMasterCard:
             return PKPaymentNetworkMasterCard;
 
         case CardNetworkVisa:
             return PKPaymentNetworkVisa;
-            
+
         case CardNetworkVisaElectron:
             if (@available(iOS 12.0, *)) {
                 return PKPaymentNetworkElectron;
             }
-         
+
         case CardNetworkMaestro:
             if (@available(iOS 12.0, *)) {
                 return PKPaymentNetworkMaestro;
             }
-            
+
         case CardNetworkElo:
             if (@available(iOS 12.1.1, *)) {
                 return PKPaymentNetworkElo;
             }
-        
+
         default:
             return nil;
     }

--- a/Tests/APITests/AuthenticationTests.swift
+++ b/Tests/APITests/AuthenticationTests.swift
@@ -40,14 +40,14 @@ class AuthenticationTests: JudoTestCase {
         
         let request = judo.transaction(for: .payment,
                                               judoId: myJudoId,
-                                              amount: oneGBPAmount,
+                                              amount: JPAmount(amount: "0.01", currency: "GBP"),
                                               reference: JPReference(consumerReference: consumerReference))
         
         XCTAssertNotNil(request,
                         "JPTransaction object must not be nil")
-        XCTAssertEqual(request?.amount?.amount, oneGBPAmount.amount,
+        XCTAssertEqual(request?.amount?.amount, "0.01",
                        "JPTransaction object must be initialized with correct amount")
-        XCTAssertEqual(request?.amount?.currency, oneGBPAmount.currency,
+        XCTAssertEqual(request?.amount?.currency, "GBP",
                        "JPTransaction object must be initialized with correct currency")
         XCTAssertEqual(request?.judoId, myJudoId,
                        "JPTransaction object must be initialized with valid Judo ID")
@@ -66,7 +66,7 @@ class AuthenticationTests: JudoTestCase {
     func test_OnInvalidTokenAndSecret_ReturnAuthenticationError() {
         
         let payment = invalidJudo.payment(withJudoId: myJudoId,
-                                                 amount: oneGBPAmount,
+                                                 amount: JPAmount(amount: "0.01", currency: "GBP"),
                                                  reference: JPReference(consumerReference: UUID().uuidString))
         
         payment.card = self.validVisaTestCard
@@ -93,7 +93,7 @@ class AuthenticationTests: JudoTestCase {
         let expectation = self.expectation(description: "testNonExistentJudoID")
         
         let payment = judo.payment(withJudoId: "1000009",
-                                          amount: oneGBPAmount,
+                                          amount: JPAmount(amount: "0.01", currency: "GBP"),
                                           reference: JPReference(consumerReference: UUID().uuidString))
         
         payment.card = validVisaTestCard
@@ -118,7 +118,7 @@ class AuthenticationTests: JudoTestCase {
         let expectation = self.expectation(description: "testInvalidJudoID")
         
         let payment = judo.payment(withJudoId: "invalid_judo_id",
-                                          amount: oneGBPAmount,
+                                          amount: JPAmount(amount: "0.01", currency: "GBP"),
                                           reference: JPReference(consumerReference: UUID().uuidString))
         
         payment.card = validVisaTestCard
@@ -141,7 +141,7 @@ class AuthenticationTests: JudoTestCase {
     func test_OnValidParameters_ReturnValidTransaction() {
 
         let payment = judo.payment(withJudoId: myJudoId,
-                                          amount: oneGBPAmount,
+                                          amount: JPAmount(amount: "0.01", currency: "GBP"),
                                           reference: JPReference(consumerReference: UUID().uuidString))
         
         payment.card = validVisaTestCard

--- a/Tests/APITests/CardDetailsSetTests.swift
+++ b/Tests/APITests/CardDetailsSetTests.swift
@@ -108,7 +108,7 @@ extension CardDetailsSetTests {
                                               paymentToken: JPPaymentToken?) -> JudoPayViewController {
         
         let vc = JudoPayViewController(judoId: myJudoId,
-                                       amount: oneGBPAmount,
+                                       amount: JPAmount(amount: "0.01", currency: "GBP"),
                                        reference: JPReference(consumerReference: UUID().uuidString),
                                        transaction: .payment,
                                        currentSession: judo,

--- a/Tests/APITests/CollectionTests.swift
+++ b/Tests/APITests/CollectionTests.swift
@@ -41,7 +41,7 @@ class CollectionTests: JudoTestCase {
         let expectation = self.expectation(description: "testPreAuth")
 
         let preAuth = judo.preAuth(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
         
         XCTAssertNotNil(preAuth,

--- a/Tests/APITests/DedupTestCase.swift
+++ b/Tests/APITests/DedupTestCase.swift
@@ -36,7 +36,7 @@ class DedupTestCase: JudoTestCase {
     func test_JPPaymentInitialization() {
         
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
         
         XCTAssertNotNil(payment,
@@ -56,7 +56,7 @@ class DedupTestCase: JudoTestCase {
     func test_OnDifferentReferences_AllowDuplicateTransactions() {
         
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
         
         payment.card = validVisaTestCard
@@ -78,7 +78,7 @@ class DedupTestCase: JudoTestCase {
             }
             
             let payment2 = self.judo.payment(withJudoId: myJudoId,
-                                             amount: self.oneGBPAmount,
+                                             amount: JPAmount(amount: "0.01", currency: "GBP"),
                                              reference: JPReference(consumerReference: UUID().uuidString))
             
             payment2.card = self.validVisaTestCard
@@ -115,7 +115,7 @@ class DedupTestCase: JudoTestCase {
     func test_OnDifferentReferences_DenyDuplicateTransactions() {
         
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
 
         payment.card = validVisaTestCard

--- a/Tests/APITests/JudoTestCase.swift
+++ b/Tests/APITests/JudoTestCase.swift
@@ -37,15 +37,6 @@ class JudoTestCase: XCTestCase {
     let validVisaTestCard = JPCard(cardNumber: "4976000000003436", expiryDate: "12/20", secureCode: "452")
     let declinedVisaTestCard = JPCard(cardNumber: "4221690000004963", expiryDate: "12/20", secureCode: "125")
     
-    // Amount
-    let oneGBPAmount = JPAmount(amount: "1.00", currency: "GBP")
-    let invalidAmount = JPAmount(amount: "", currency: "GBP")
-    let invalidCurrencyAmount = JPAmount(amount: "1.00", currency: "")
-    
-    // References
-    let validReference = JPReference(consumerReference: "consumer reference")
-    let invalidReference = JPReference(consumerReference: "")
-    
     // VCO Result
     let validVCOResult = JPVCOResult(callId: "2587385100467218001",
                                      encryptedKey: "xJRr2tLAs0n0ztToEMhhG8ELBg3mi7TKLVuqn4pA3FAHhgvR29y1YUhVMdrradFw6gk6+XwF05JEdL6uSWhjH8ZMZoBUsHbglqtg0pnm8tbDQzmaBzztLnOaPbwVYLe8",
@@ -74,6 +65,6 @@ extension JudoTestCase {
         }
         
         XCTAssertEqual(error.code, Int(judoError.rawValue),
-                       "Error must return code: \(judoError.rawValue) instead of \(error.code)")
+                       "Error must return code: \(error.code) instead of \(judoError.rawValue)")
     }
 }

--- a/Tests/APITests/PaymentTests.swift
+++ b/Tests/APITests/PaymentTests.swift
@@ -51,7 +51,7 @@ class PaymentTests: JudoTestCase {
     func test_OnValidJPPayment_ReturnResponse() {
 
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
         
         payment.card = validVisaTestCard
@@ -177,7 +177,7 @@ class PaymentTests: JudoTestCase {
     func test_OnPaymentWithoutReference_ReturnError() {
 
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: ""))
         
         payment.card = validVisaTestCard
@@ -208,7 +208,7 @@ class PaymentTests: JudoTestCase {
                                     paymentReference: "")
         
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: reference)
         
         payment.card = validVisaTestCard
@@ -240,7 +240,7 @@ class PaymentTests: JudoTestCase {
                                     paymentReference: " ")
         
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: reference)
         
         payment.card = validVisaTestCard
@@ -272,7 +272,7 @@ class PaymentTests: JudoTestCase {
                                     paymentReference: String(repeating: "a", count: 51))
         
         let payment = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: reference)
         
         payment.card = validVisaTestCard

--- a/Tests/APITests/PreAuthTests.swift
+++ b/Tests/APITests/PreAuthTests.swift
@@ -50,7 +50,7 @@ class PreAuthTests: JudoTestCase {
     func test_OnValidJPPreAuth_ReturnResponse() {
         
         let preAuth = judo.preAuth(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
         
         preAuth.card = validVisaTestCard
@@ -176,7 +176,7 @@ class PreAuthTests: JudoTestCase {
     func test_OnPreAuthWithoutReference_ReturnError() {
         
         let preAuth = judo.preAuth(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: ""))
         
         preAuth.card = validVisaTestCard
@@ -207,7 +207,7 @@ class PreAuthTests: JudoTestCase {
                                     paymentReference: "")
         
         let preAuth = judo.preAuth(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: reference)
         
         preAuth.card = validVisaTestCard
@@ -239,7 +239,7 @@ class PreAuthTests: JudoTestCase {
                                     paymentReference: " ")
         
         let preAuth = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: reference)
         
         preAuth.card = validVisaTestCard
@@ -271,7 +271,7 @@ class PreAuthTests: JudoTestCase {
                                     paymentReference: String(repeating: "a", count: 51))
         
         let preAuth = judo.preAuth(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: reference)
         
         preAuth.card = validVisaTestCard

--- a/Tests/APITests/ReceiptTests.swift
+++ b/Tests/APITests/ReceiptTests.swift
@@ -27,52 +27,83 @@ import XCTest
 
 class ReceiptTests: JudoTestCase {
     
-    func testJudoTransactionReceipt() {
+    /**
+     * GIVEN: I make a payment with valid parameters and get a valid receipt ID
+     *
+     * WHEN:  I use the receipt ID to create a JPReceipt object and call the 'send' method
+     *
+     * THEN:  I should get back a succesful response and no error for a specific receipt
+     */
+    func test_OnValidReceiptID_JPReceiptReturnsValidResponse() {
 
-        let initialPayment = judo.payment(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+        let initialPayment = judo.payment(withJudoId: myJudoId,
+                                          amount: oneGBPAmount,
+                                          reference: JPReference(consumerReference: UUID().uuidString))
         
         initialPayment.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "receipt fetch expectation")
+        let expectation = self.expectation(description: "testReceipt")
         
         initialPayment.send(completion: { (response, error) -> () in
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
+                XCTFail("API call failed with error: \(error)")
             }
             
-            XCTAssertNotNil(response)
-            XCTAssertNotNil(response?.items?.first)
-            let receiptId = response?.items?.first?.receiptId as String?
+            guard let receiptId = response?.items?.first?.receiptId as String? else {
+                XCTFail("Receipt ID must not be nil on valid payment configuration")
+                return
+            }
+
+            XCTAssertFalse(receiptId.isEmpty,
+                          "Receipt ID must not be empty on valid payment configuration")
             
-            // Given i have a valid receiptID
-            XCTAssertNotNil(receiptId, "Null receiptId");
-            XCTAssertTrue(receiptId?.count != 0, "Empty receiptId")
-            XCTAssertNotNil(initialPayment)
-            XCTAssertEqual(initialPayment.judoId, myJudoId)
+            let receipt = self.judo.receipt(receiptId);
             
-            let payment = self.judo.payment(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.validReference)
-            XCTAssertNotNil(payment)
-            
-            self.judo.receipt(receiptId).send(completion: { (dict, error) -> () in
+            receipt.send(completion: { (response, error) -> () in
+                
                 if let error = error {
-                    XCTFail("api call failed with error: \(error)")
+                    XCTFail("API call failed with error: \(error)")
                 }
+                
+                XCTAssertNotNil(response,
+                                "Response must not be nil on valid receipt")
+                
+                XCTAssertNotNil(response?.items?.first,
+                                "Response must contain at least one JPTransactionData object")
+                
                 expectation.fulfill()
             })
         })
         
         self.waitForExpectations(timeout: 30.0, handler: nil)
-        
     }
     
-    func testJudoTransactionAllReceipts() {
-        // Given
-        let expectation = self.expectation(description: "all receipts fetch expectation")
+    /**
+     * GIVEN: I create a JPReceipt object without any receipt ID
+     *
+     * WHEN:  I call the 'send' method of the JPReceipt object
+     *
+     * THEN:  I should get back a succesful response and no error for all receipts
+     */
+    func test_OnNoReceiptID_JPReceiptReturnsValidResponse() {
+
+        let expectation = self.expectation(description: "testAllReceipts")
         
-        judo.receipt(nil).send(completion: { (dict, error) -> () in
+        let receipt = judo.receipt(nil)
+        
+        receipt.send(completion: { (response, error) -> () in
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            XCTAssertNotNil(response,
+                            "Response must not be nil on valid receipt")
+            
+            XCTAssertNotNil(response?.items?.first,
+                            "Response must contain at least one JPTransactionData object")
+            
             expectation.fulfill()
         })
         
@@ -80,24 +111,42 @@ class ReceiptTests: JudoTestCase {
         
     }
     
-    
-    func testJudoTransactionReceiptWithPagination() {
-        // Given
+    /**
+     * GIVEN: I create a JPReceipt object and a JPPagination object
+     *
+     * WHEN:  I call the 'list' method and provide the pagination object
+     *
+     * THEN:  I should get back a succesful paginated response and no error
+     */
+    func test_OnPaginationProvided_JPReceiptReturnsValidResponse() {
+
         let page = JPPagination(offset: 8, pageSize: 4, sort: "time-ascending")
-        let expectation = self.expectation(description: "all receipts fetch expectation")
         
+        let expectation = self.expectation(description: "testReceiptPagination")
+
         let receipt = judo.receipt(nil)
-        
-        receipt.list(with: page) { (dict, error) -> () in
+
+        receipt.list(with: page) { (response, error) -> () in
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                XCTAssertEqual(dict!.items?.count, 4)
-                XCTAssertEqual(dict!.pagination!.offset, 8)
+                XCTFail("API call failed with error: \(error)")
+                return
             }
+            
+            guard let response = response else {
+                XCTFail("Valid JPResponse must be returned on valid configuration")
+                return
+            }
+            
+            XCTAssertEqual(response.items?.count, 4,
+                           "Item count must match the one specified in the JPPagination object")
+            
+            XCTAssertEqual(response.pagination!.offset, 8,
+                           "Item offset must match the one specified in the JPPagination object")
+
             expectation.fulfill()
         }
-        
+
         self.waitForExpectations(timeout: 30.0, handler: nil)
     }
     

--- a/Tests/APITests/ReceiptTests.swift
+++ b/Tests/APITests/ReceiptTests.swift
@@ -37,7 +37,7 @@ class ReceiptTests: JudoTestCase {
     func test_OnValidReceiptID_JPReceiptReturnsValidResponse() {
 
         let initialPayment = judo.payment(withJudoId: myJudoId,
-                                          amount: oneGBPAmount,
+                                          amount: JPAmount(amount: "0.01", currency: "GBP"),
                                           reference: JPReference(consumerReference: UUID().uuidString))
         
         initialPayment.card = validVisaTestCard

--- a/Tests/APITests/RefundTests.swift
+++ b/Tests/APITests/RefundTests.swift
@@ -27,49 +27,59 @@ import XCTest
 
 class RefundTests: JudoTestCase {
     
-    func testRefund() {
+    /**
+     * GIVEN: I make a transaction and get a valid receipt ID and amount
+     *
+     * WHEN:  I create a JPRefund object with the receipt ID and amount and call 'send'
+     *
+     * THEN:  I should get back a succesful response and no error
+     */
+    func test_OnValidReceiptIDAndAmount_ReturnValidResponse() {
         
-        let expectation = self.expectation(description: "payment expectation")
+        let expectation = self.expectation(description: "testRefund")
         
-        // Given I have made a payment
-        let preAuth = judo.payment(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+        let preAuth = judo.payment(withJudoId: myJudoId,
+                                   amount: oneGBPAmount,
+                                   reference: JPReference(consumerReference: UUID().uuidString))
+        
         preAuth.card = validVisaTestCard
         
         preAuth.send(completion: { (response, error) -> () in
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-                expectation.fulfill()
+                XCTFail("API call failed with error: \(error)")
                 return
             }
             
-            // And I have a receipt ID of a given transaction
-            // And I have the amount of that transaction
-            guard let receiptId = response?.items?.first?.receiptId,
-                let amount = response?.items?.first?.amount else {
-                    XCTFail("receipt ID was not available in response")
-                    expectation.fulfill()
-                    return
+            guard let receiptId = response?.items?.first?.receiptId else {
+                XCTFail("Receipt ID was not available in response.")
+                return
             }
             
-            // When I perform a refund up to the original amount
+            guard let amount = response?.items?.first?.amount else {
+                XCTFail("Amount was not available in response.")
+                return
+            }
+            
             let refund = self.judo.refund(withReceiptId: receiptId, amount: amount)
+            
             refund.send(completion: { (response, error) -> () in
-                // Then I receive a successful response
+
                 if let error = error {
-                    XCTFail("api call failed with error: \(error)")
+                    XCTFail("API call failed with error: \(error)")
                 }
                 
-                XCTAssertNotNil(response)
-                XCTAssertNotNil(response?.items?.first)
+                XCTAssertNotNil(response,
+                                "Response must not be nil on valid receipt")
+                
+                XCTAssertNotNil(response?.items?.first,
+                                "Response must contain at least one JPTransactionData object")
                 
                 expectation.fulfill();
             })
             
             XCTAssertNotNil(refund)
         })
-        
-        XCTAssertNotNil(preAuth)
-        XCTAssertEqual(preAuth.judoId, myJudoId)
         
         self.waitForExpectations(timeout: 30, handler: nil)
         

--- a/Tests/APITests/RefundTests.swift
+++ b/Tests/APITests/RefundTests.swift
@@ -39,7 +39,7 @@ class RefundTests: JudoTestCase {
         let expectation = self.expectation(description: "testRefund")
         
         let preAuth = judo.payment(withJudoId: myJudoId,
-                                   amount: oneGBPAmount,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
                                    reference: JPReference(consumerReference: UUID().uuidString))
         
         preAuth.card = validVisaTestCard

--- a/Tests/APITests/RegisterCardTests.swift
+++ b/Tests/APITests/RegisterCardTests.swift
@@ -36,7 +36,9 @@ class RegisterCardTests: JudoTestCase {
     func test_OnValidParameters_JPRegisterCardInitializesSuccesfully() {
         let registration = judo.registerCard(withJudoId: myJudoId,
                                              reference: JPReference(consumerReference: UUID().uuidString))
-        XCTAssertNotNil(registration)
+        
+        XCTAssertNotNil(registration,
+                        "JPRegisterCard should be succesfully initialized with valid parameters")
     }
     
     /**

--- a/Tests/APITests/RegisterCardTests.swift
+++ b/Tests/APITests/RegisterCardTests.swift
@@ -28,81 +28,77 @@ import CoreLocation
 
 class RegisterCardTests: JudoTestCase {
     
-    func testRegisterCard() {
-        let payment = judo.registerCard(withJudoId: myJudoId, reference: validReference)
-        XCTAssertNotNil(payment)
+    /**
+     * GIVEN: I call JudoKit's `registerCard` method with valid Judo ID and reference
+     *
+     * THEN:  I should be able to initialize a valid JPRegisterCard object
+     */
+    func test_OnValidParameters_JPRegisterCardInitializesSuccesfully() {
+        let registration = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
+        XCTAssertNotNil(registration)
     }
     
-    func testJudoMakeValidRegisterCard() {
-        // Given I have a Register Card
-        let payment = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have a valid JPRegisterCard object
+     *
+     * WHEN:  I call its 'send' method to register the card
+     *
+     * THEN:  I should get back a succesful response and no error
+     */
+    func test_OnValidJPRegisterCard_ValidJPResponeMustBeReturned() {
         
-        // When I provide all the required fields
-        payment.card = validVisaTestCard
+        let registration = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
         
-        // Then I should be able to register a card
-        let expectation = self.expectation(description: "payment expectation")
         
-        payment.send(completion: { (response, error) -> () in
+        registration.card = validVisaTestCard
+        
+        let expectation = self.expectation(description: "testRegistration")
+        
+        registration.send(completion: { (response, error) -> () in
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
+                XCTFail("API call failed with error: \(error)")
             }
-            XCTAssertNotNil(response)
-            XCTAssertNotNil(response?.items?.first)
-            expectation.fulfill()
-        })
-        
-        XCTAssertNotNil(payment)
-        XCTAssertEqual(payment.judoId, myJudoId)
-        
-        self.waitForExpectations(timeout: 30, handler: nil)
-    }
-    
-    func testJudoMakeValidRegisterCardWithDeviceSignals() {
-        // Given I have a Register Card
-        let payment = judo.registerCard(withJudoId: myJudoId, reference: validReference)
-        
-        // When I provide all the required fields
-        payment.card = validVisaTestCard
-        
-        // Then I should be able to register a card
-        let expectation = self.expectation(description: "payment expectation")
-        
-        judo.send(withCompletion: payment, completion: { (response, error) in
-            if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            }
-            XCTAssertNotNil(response)
-            XCTAssertNotNil(response?.items?.first)
-            expectation.fulfill()
-        })
-        
-        XCTAssertNotNil(payment)
-        XCTAssertEqual(payment.judoId, myJudoId)
-        
-        self.waitForExpectations(timeout: 30, handler: nil)
-    }
-    
-    func testRegisterCardWithInvalidReference() {
-        // Given I have a Register Card
-        // When I do not provide a consumer reference
-        let payment = judo.registerCard(withJudoId: myJudoId, reference: invalidReference)
-        
-        payment.card = validVisaTestCard
-        
-        // Then I should receive an error
-        let expectation = self.expectation(description: "payment expectation")
-        
-        payment.send(completion: { (response, error) -> () in
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
-            XCTAssertEqual(error!._code, Int(JudoError.errorGeneral_Model_Error.rawValue))
+            
+            XCTAssertNotNil(response,
+                            "Response must not be nil on valid receipt")
+            
+            XCTAssertNotNil(response?.items?.first,
+                            "Response must contain at least one JPTransactionData object")
             
             expectation.fulfill()
         })
         
-        XCTAssertNotNil(payment)
-        XCTAssertEqual(payment.judoId, myJudoId)
+        self.waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    /**
+     * GIVEN: I have a JPRegisterCard object with an invalid reference
+     *
+     * WHEN:  I call its 'send' method to register the card
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnJPRegisterCardWithInvalidReference_ReturnError() {
+        
+        let registration = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: ""))
+        
+        registration.card = validVisaTestCard
+        
+        let expectation = self.expectation(description: "testInvalidReference")
+        
+        registration.send(completion: { [weak self] (response, error) -> () in
+            
+            XCTAssertNil(response,
+                         "JPResponse must be nil on JPRegisterCard with invalid reference")
+            
+            self?.assert(error: error, as: .errorGeneral_Model_Error)
+            
+            expectation.fulfill()
+        })
         
         self.waitForExpectations(timeout: 30, handler: nil)
     }

--- a/Tests/APITests/TokenPaymentTests.swift
+++ b/Tests/APITests/TokenPaymentTests.swift
@@ -27,155 +27,215 @@ import XCTest
 
 class TokenPaymentTests: JudoTestCase {
     
-    func testJudoMakeValidTokenPayment() {
-        // Given I have an SDK
-        // When I provide the required fields
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have registered a card and obtained a valid consumer and card token
+     *
+     * WHEN:  I make a payment with an initialized JPPaymentToken
+     *
+     * THEN:  I should get back a valid JPResponse and no error
+     */
+    func test_OnValidJPPaymentToken_ReturnValidJPResponse() {
+        
+        let reference = JPReference(consumerReference: UUID().uuidString)
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: reference)
         
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testTokenPayment")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (response, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                guard let uData = data else {
-                    XCTFail("no data available")
-                    return
+                XCTFail("API call failed with error: \(error)")
+            }
+            
+            guard let consumerToken = response?.items?.first?.consumer.consumerToken else {
+                XCTFail("No consumer token found in response")
+                return
+            }
+            guard let cardToken = response?.items?.first?.cardDetails?.cardToken else {
+                XCTFail("No card token found in response")
+                return
+            }
+            
+            let paymentToken = JPPaymentToken(consumerToken: consumerToken, cardToken: cardToken)
+            
+            paymentToken.secureCode = self.validVisaTestCard.secureCode
+            
+            let payment = self.judo.payment(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                            reference: reference)
+            
+            payment.paymentToken = paymentToken
+            
+            payment.send(completion: { (response, error) -> () in
+                
+                if let error = error {
+                    XCTFail("API call failed with error: \(error)")
                 }
                 
-                let consumerToken = uData.items?.first?.consumer.consumerToken
-                let cardToken = uData.items?.first?.cardDetails?.cardToken
+                XCTAssertNotNil(response,
+                                "Response must not be nil on valid receipt")
                 
-                let payToken = JPPaymentToken(consumerToken: consumerToken!, cardToken: cardToken!)
+                XCTAssertNotNil(response?.items?.first,
+                                "Response must contain at least one JPTransactionData object")
                 
-                payToken.secureCode = self.validVisaTestCard.secureCode
-                
-                // Then I should be able to make a token payment
-                let payment = self.judo.payment(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.validReference)
-                payment.paymentToken = payToken
-                payment.send(completion: { (data, error) -> () in
-                    if let error = error {
-                        XCTFail("api call failed with error: \(error)")
-                    }
-                    expectation.fulfill()
-                })
-            }
+                expectation.fulfill()
+            })
+            
         })
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
         
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
-    func testJudoMakeTokenPaymentWithoutToken() {
-        // Given I have an SDK
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have a JPRegisterCard object and registered the card
+     *
+     * WHEN:  I make a payment without passing a JPPaymentToken
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnNoJPPaymentToken_ReturnError() {
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
+        
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testNoTokenPayment")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (_, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                
-                // When I do not provide a card token
-                let payment = self.judo.payment(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.validReference)
-                payment.send(completion: { (data, error) -> () in
-                    XCTAssertEqual(error!._code, Int(JudoError.errorPaymentMethodMissing.rawValue))
-                    expectation.fulfill()
-                })
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            let payment = self.judo.payment(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                            reference: JPReference(consumerReference: UUID().uuidString))
+            
+            payment.send(completion: { [weak self] (response, error) -> () in
+                XCTAssertNil(response, "Response must be nil when no payment token has been passed")
+                self?.assert(error: error, as: .errorPaymentMethodMissing)
+                expectation.fulfill()
+            })
+            
         })
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
-        
+
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
-    func testJudoMakeTokenPaymentWithoutReference() {
-        // Given I have an SDK
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have registered the card with some reference ID
+     *
+     * WHEN: I make a payment with a different reference ID
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnWrongReferencePassed_ReturnError() {
+
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testDifferentReferences")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (response, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                guard let uData = data else {
-                    XCTFail("no data available")
-                    return
-                }
-                
-                let consumerToken = uData.items?.first?.consumer.consumerToken
-                let cardToken = uData.items?.first?.cardDetails?.cardToken
-                
-                let payToken = JPPaymentToken(consumerToken: consumerToken!, cardToken: cardToken!)
-                
-                // When I do not provide a consumer reference
-                // Then I should receive an error
-                let payment = self.judo.payment(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.invalidReference)
-                payment.paymentToken = payToken
-                payment.send(completion: { (response, error) -> () in
-                    XCTAssertNil(response)
-                    XCTAssertNotNil(error)
-                    XCTAssertEqual(error!._code, Int(JudoError.errorGeneral_Model_Error.rawValue))
-                    
-                    expectation.fulfill()
-                })
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            guard let consumerToken = response?.items?.first?.consumer.consumerToken else {
+                XCTFail("No consumer token found in response")
+                return
+            }
+            guard let cardToken = response?.items?.first?.cardDetails?.cardToken else {
+                XCTFail("No card token found in response")
+                return
+            }
+            
+            let paymentToken = JPPaymentToken(consumerToken: consumerToken, cardToken: cardToken)
+            
+            paymentToken.secureCode = self.validVisaTestCard.secureCode
+            
+            let payment = self.judo.payment(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                            reference: JPReference(consumerReference: UUID().uuidString))
+            
+            payment.paymentToken = paymentToken
+            
+            payment.send(completion: { [weak self] (response, error) -> () in
+                XCTAssertNil(response, "Response must be nil invalid reference has been passed")
+                self?.assert(error: error, as: .errorCardTokenDoesntMatchConsumer)
+                expectation.fulfill()
+            })
         })
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
-        
+            
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
-    func testJudoMakeTokenPaymentWithoutAmount() {
-        // Given I have an SDK
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have registered the card and got back card and consumer tokens
+     *
+     * WHEN:  I make a payment with an invalid amount
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnTokenPaymentWithoutAmount_ReturnError() {
+
+        let reference = JPReference(consumerReference: UUID().uuidString)
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: reference)
+        
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testInvalidAmount")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (response, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                guard let uData = data else {
-                    XCTFail("no data available")
-                    return 
-                }
-                
-                let consumerToken = uData.items?.first?.consumer.consumerToken
-                let cardToken = uData.items?.first?.cardDetails?.cardToken
-                
-                let payToken = JPPaymentToken(consumerToken: consumerToken!, cardToken: cardToken!)
-                
-                // When I do not provide an amount
-                // Then I should receive an error
-                let payment = self.judo.payment(withJudoId: myJudoId, amount: self.invalidCurrencyAmount, reference: self.validReference)
-                payment.paymentToken = payToken
-                payment.send(completion: { (response, error) -> () in
-                    XCTAssertNil(response)
-                    XCTAssertNotNil(error)
-                    XCTAssertEqual(error!._code, Int(JudoError.errorGeneral_Model_Error.rawValue))
-                    
-                    expectation.fulfill()
-                })
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            guard let consumerToken = response?.items?.first?.consumer.consumerToken else {
+                XCTFail("No consumer token found in response")
+                return
+            }
+            guard let cardToken = response?.items?.first?.cardDetails?.cardToken else {
+                XCTFail("No card token found in response")
+                return
+            }
+            
+            let paymentToken = JPPaymentToken(consumerToken: consumerToken, cardToken: cardToken)
+            
+            paymentToken.secureCode = self.validVisaTestCard.secureCode
+            
+            let payment = self.judo.payment(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "", currency: "GBP"),
+                                            reference: JPReference(consumerReference: UUID().uuidString))
+            
+            payment.paymentToken = paymentToken
+            
+            payment.send(completion: { [weak self] (response, error) -> () in
+                XCTAssertNil(response, "Response must be nil when invalid amount has been passed")
+                self?.assert(error: error, as: .errorGeneral_Model_Error)
+                expectation.fulfill()
+            })
+            
         })
-        // Then
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
-        
+ 
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     

--- a/Tests/APITests/TokenPreAuthTests.swift
+++ b/Tests/APITests/TokenPreAuthTests.swift
@@ -27,154 +27,214 @@ import XCTest
 
 class TokenPreAuthTests: JudoTestCase {
     
-    func testJudoMakeValidTokenPreAuth() {
-        // Given I have an SDK
-        // When I provide the required fields
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have registered a card and obtained a valid consumer and card token
+     *
+     * WHEN:  I make a preAuth with an initialized JPPaymentToken
+     *
+     * THEN:  I should get back a valid JPResponse and no error
+     */
+    func test_OnValidJPPaymentToken_ReturnValidJPResponse() {
+        
+        let reference = JPReference(consumerReference: UUID().uuidString)
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: reference)
+        
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testTokenPayment")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (response, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                guard let uData = data else {
-                    XCTFail("no data available")
-                    return
+                XCTFail("API call failed with error: \(error)")
+            }
+            
+            guard let consumerToken = response?.items?.first?.consumer.consumerToken else {
+                XCTFail("No consumer token found in response")
+                return
+            }
+            guard let cardToken = response?.items?.first?.cardDetails?.cardToken else {
+                XCTFail("No card token found in response")
+                return
+            }
+            
+            let paymentToken = JPPaymentToken(consumerToken: consumerToken, cardToken: cardToken)
+            
+            paymentToken.secureCode = self.validVisaTestCard.secureCode
+            
+            let preAuth = self.judo.preAuth(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                            reference: reference)
+            
+            preAuth.paymentToken = paymentToken
+            
+            preAuth.send(completion: { (response, error) -> () in
+                
+                if let error = error {
+                    XCTFail("API call failed with error: \(error)")
                 }
                 
-                let consumerToken = uData.items?.first?.consumer.consumerToken
-                let cardToken = uData.items?.first?.cardDetails?.cardToken
+                XCTAssertNotNil(response,
+                                "Response must not be nil on valid receipt")
                 
-                let payToken = JPPaymentToken(consumerToken: consumerToken!, cardToken: cardToken!)
+                XCTAssertNotNil(response?.items?.first,
+                                "Response must contain at least one JPTransactionData object")
                 
-                payToken.secureCode = self.validVisaTestCard.secureCode
-                
-                // Then I should be able to make a token Pre-authorization
-                let preAuth = self.judo.preAuth(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.validReference)
-                preAuth.paymentToken = payToken
-                preAuth.send(completion: { (data, error) -> () in
-                    if let error = error {
-                        XCTFail("api call failed with error: \(error)")
-                    }
-                    expectation.fulfill()
-                })
-            }
+                expectation.fulfill()
+            })
+            
         })
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
         
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
-    func testJudoMakeTokenPreAuthWithoutToken() {
-        // Given I have an SDK
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have a JPRegisterCard object and registered the card
+     *
+     * WHEN:  I make a preAuth without passing a JPPaymentToken
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnNoJPPaymentToken_ReturnError() {
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
+        
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testNoTokenPayment")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (_, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                
-                // When I do not provide a card token
-                let preAuth = self.judo.preAuth(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.validReference)
-                preAuth.send(completion: { (data, error) -> () in
-                    // Then I should receive an error
-                    XCTAssertEqual(error!._code, Int(JudoError.errorPaymentMethodMissing.rawValue))
-                    expectation.fulfill()
-                })
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            let preAuth = self.judo.preAuth(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                            reference: JPReference(consumerReference: UUID().uuidString))
+            
+            preAuth.send(completion: { [weak self] (response, error) -> () in
+                XCTAssertNil(response, "Response must be nil when no preAuth token has been passed")
+                self?.assert(error: error, as: .errorPaymentMethodMissing)
+                expectation.fulfill()
+            })
+            
         })
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
         
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
-    func testJudoMakeTokenPreAuthWithoutReference() {
-        // Given I have an SDK
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have registered the card with some reference ID
+     *
+     * WHEN: I make a preAuth with a different reference ID
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnWrongReferencePassed_ReturnError() {
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testDifferentReferences")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (response, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                guard let uData = data else {
-                    XCTFail("no data available")
-                    return
-                }
-                
-                let consumerToken = uData.items?.first?.consumer.consumerToken
-                let cardToken = uData.items?.first?.cardDetails?.cardToken
-                
-                let payToken = JPPaymentToken(consumerToken: consumerToken!, cardToken: cardToken!)
-                
-                // When I do not provide a consumer reference
-                // Then I should receive an error
-                let preAuth = self.judo.preAuth(withJudoId: myJudoId, amount: self.oneGBPAmount, reference: self.invalidReference)
-                preAuth.paymentToken = payToken
-                preAuth.send(completion: { (response, error) -> () in
-                    XCTAssertNil(response)
-                    XCTAssertNotNil(error)
-                    XCTAssertEqual(error!._code, Int(JudoError.errorGeneral_Model_Error.rawValue))
-                    
-                    expectation.fulfill()
-                })
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            guard let consumerToken = response?.items?.first?.consumer.consumerToken else {
+                XCTFail("No consumer token found in response")
+                return
+            }
+            guard let cardToken = response?.items?.first?.cardDetails?.cardToken else {
+                XCTFail("No card token found in response")
+                return
+            }
+            
+            let paymentToken = JPPaymentToken(consumerToken: consumerToken, cardToken: cardToken)
+            
+            paymentToken.secureCode = self.validVisaTestCard.secureCode
+            
+            let preAuth = self.judo.preAuth(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                            reference: JPReference(consumerReference: UUID().uuidString))
+            
+            preAuth.paymentToken = paymentToken
+            
+            preAuth.send(completion: { [weak self] (response, error) -> () in
+                XCTAssertNil(response, "Response must be nil when invalid reference has been passed")
+                self?.assert(error: error, as: .errorCardTokenDoesntMatchConsumer)
+                expectation.fulfill()
+            })
         })
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
         
         self.waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
-    func testJudoMakeTokenPreAuthWithoutAmount() {
-        // Given I have an SDK
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+    /**
+     * GIVEN: I have registered the card and got back card and consumer tokens
+     *
+     * WHEN:  I make a preAuth with an invalid amount
+     *
+     * THEN:  I should get back an error and no response
+     */
+    func test_OnTokenPreAuthWithoutAmount_ReturnError() {
+        
+        let reference = JPReference(consumerReference: UUID().uuidString)
+        
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: reference)
+        
         registerCard.card = validVisaTestCard
         
-        let expectation = self.expectation(description: "token payment expectation")
+        let expectation = self.expectation(description: "testInvalidAmount")
         
-        registerCard.send(completion: { (data, error) -> () in
+        registerCard.send(completion: { [weak self] (response, error) -> () in
+            
+            guard let self = self else { return }
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                guard let uData = data else {
-                    XCTFail("no data available")
-                    return 
-                }
-                
-                let consumerToken = uData.items?.first?.consumer.consumerToken
-                let cardToken = uData.items?.first?.cardDetails?.cardToken
-                
-                let payToken = JPPaymentToken(consumerToken: consumerToken!, cardToken: cardToken!)
-                
-                // When I do not provide an amount
-                // Then I should receive an error
-                let preAuth = self.judo.preAuth(withJudoId: myJudoId, amount: self.invalidCurrencyAmount, reference: self.validReference)
-                preAuth.paymentToken = payToken
-                preAuth.send(completion: { (response, error) -> () in
-                    XCTAssertNil(response)
-                    XCTAssertNotNil(error)
-                    XCTAssertEqual(error!._code, Int(JudoError.errorGeneral_Model_Error.rawValue))
-                    
-                    expectation.fulfill()
-                })
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            guard let consumerToken = response?.items?.first?.consumer.consumerToken else {
+                XCTFail("No consumer token found in response")
+                return
+            }
+            guard let cardToken = response?.items?.first?.cardDetails?.cardToken else {
+                XCTFail("No card token found in response")
+                return
+            }
+            
+            let paymentToken = JPPaymentToken(consumerToken: consumerToken, cardToken: cardToken)
+            
+            paymentToken.secureCode = self.validVisaTestCard.secureCode
+            
+            let preAuth = self.judo.preAuth(withJudoId: myJudoId,
+                                            amount: JPAmount(amount: "", currency: "GBP"),
+                                            reference: JPReference(consumerReference: UUID().uuidString))
+            
+            preAuth.paymentToken = paymentToken
+            
+            preAuth.send(completion: { [weak self] (response, error) -> () in
+                XCTAssertNil(response, "Response must be nil when invalid amount has been passed")
+                self?.assert(error: error, as: .errorGeneral_Model_Error)
+                expectation.fulfill()
+            })
+            
         })
-        // Then
-        XCTAssertNotNil(registerCard)
-        XCTAssertEqual(registerCard.judoId, myJudoId)
         
         self.waitForExpectations(timeout: 30, handler: nil)
     }

--- a/Tests/APITests/TransactionEnricherTests.swift
+++ b/Tests/APITests/TransactionEnricherTests.swift
@@ -27,9 +27,21 @@ import XCTest
 
 class TransactionEnricherTests: JudoTestCase {
     
+    /**
+     * GIVEN: I have an enriched JPPayment object
+     *
+     *  WHEN: I make a payment with the enriched object
+     *
+     *  THEN: JPPayment's `paymentDetails` must be populated with valid data
+     */
     func testEnrichPaymentTransaction() {
-        let payment = judo.payment(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+        
+        let payment = judo.payment(withJudoId: myJudoId,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                   reference: JPReference(consumerReference: UUID().uuidString))
+        
         payment.card = validVisaTestCard
+        
         let expectation = self.expectation(description: "expectation")
         
         payment.send(completion: { (response, error) -> () in
@@ -41,8 +53,17 @@ class TransactionEnricherTests: JudoTestCase {
         }
     }
     
+    /**
+     * GIVEN: I have an enriched JPPreAuth object
+     *
+     *  WHEN: I make a preAuth with the enriched object
+     *
+     *  THEN: JPPreAuth `paymentDetails` must be populated with valid data
+     */
     func testEnrichPreAuthTransaction() {
-        let preAuth = judo.preAuth(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+        let preAuth = judo.preAuth(withJudoId: myJudoId,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                   reference: JPReference(consumerReference: UUID().uuidString))
         preAuth.card = validVisaTestCard
         let expectation = self.expectation(description: "expectation")
         
@@ -55,8 +76,16 @@ class TransactionEnricherTests: JudoTestCase {
         }
     }
     
+    /**
+     * GIVEN: I have an enriched JPRegisterCard object
+     *
+     *  WHEN: I make a card registration with the enriched object
+     *
+     *  THEN: JPRegisterCard `paymentDetails` must be populated with valid data
+     */
     func testEnrichRegisterCardTransaction() {
-        let registerCard = judo.registerCard(withJudoId: myJudoId, reference: validReference)
+        let registerCard = judo.registerCard(withJudoId: myJudoId,
+                                             reference: JPReference(consumerReference: UUID().uuidString))
         registerCard.card = validVisaTestCard
         let expectation = self.expectation(description: "expectation")
 
@@ -69,8 +98,16 @@ class TransactionEnricherTests: JudoTestCase {
         }
     }
 
+    /**
+     * GIVEN: I have an enriched JPSaveCard object
+     *
+     *  WHEN: I make a card save with the enriched object
+     *
+     *  THEN: JPSaveCard `paymentDetails` must be populated with valid data
+     */
     func testNotEnrichSaveCardTransaction() {
-        let saveCard = self.judo.saveCard(withJudoId: myJudoId, reference: validReference)
+        let saveCard = self.judo.saveCard(withJudoId: myJudoId,
+                                          reference: JPReference(consumerReference: UUID().uuidString))
         let expectation = self.expectation(description: "expectation")
 
         saveCard.send(completion: { (response, error) -> () in
@@ -82,8 +119,17 @@ class TransactionEnricherTests: JudoTestCase {
         }
     }
     
+    /**
+     * GIVEN: I have an enriched JPPayment object with
+     *
+     *  WHEN: I make a payment with the enriched object
+     *
+     *  THEN: JPPayment should have valid SDK info stored
+     */
     func testEnrichTransactionWithSDKInfo() {
-        let payment = judo.payment(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+        let payment = judo.payment(withJudoId: myJudoId,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                   reference: JPReference(consumerReference: UUID().uuidString))
         payment.card = validVisaTestCard
         let expectation = self.expectation(description: "expectation")
         
@@ -100,8 +146,17 @@ class TransactionEnricherTests: JudoTestCase {
         }
     }
     
+    /**
+     * GIVEN: I have an enriched JPPayment object
+     *
+     *  WHEN: I make a payment with the enriched object
+     *
+     *  THEN: JPPayment should have valid consumer device info stored
+     */
     func testEnrichTransactionWithConsumerDevice() {
-        let payment = judo.payment(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+        let payment = judo.payment(withJudoId: myJudoId,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                   reference: JPReference(consumerReference: UUID().uuidString))
         payment.card = validVisaTestCard
         let expectation = self.expectation(description: "expectation")
         

--- a/Tests/APITests/VCOTests.swift
+++ b/Tests/APITests/VCOTests.swift
@@ -27,26 +27,39 @@ import XCTest
 @testable import JudoKitObjC
 
 class VCOTests : JudoTestCase {
-    func testVCOTransaction() {
-        // Given I have a Transaction
-        let makePayment: JPTransaction = judo.payment(withJudoId: myJudoId, amount: oneGBPAmount, reference: validReference)
+    
+    /**
+     * GIVEN: I want to make a payment with valid amount, Judo ID and reference
+     *
+     *  WHEN: I select valid Visa Checkout details
+     *
+     *  THEN: I should obtain a valid JPResponse and no error
+     */
+    func test_OnValidVisaCheckout_ReturnJPResponse() {
 
-        // And I have a valid Visa Checkout result
-        makePayment.setVCOResult(validVCOResult)
+        let payment = judo.payment(withJudoId: myJudoId,
+                                   amount: JPAmount(amount: "0.01", currency: "GBP"),
+                                   reference: JPReference(consumerReference: UUID().uuidString))
 
-        let expectation = self.expectation(description: "testTransactionExpectation")
+        payment.setVCOResult(validVCOResult)
 
-        // When I submit the card details
-        makePayment.send(completion: { (response, error) -> () in
+        let expectation = self.expectation(description: "testVisaCheckout")
+
+        payment.send(completion: { (response, error) -> () in
+            
             if let error = error {
-                XCTFail("api call failed with error: \(error)")
-            } else {
-                // And the transaction is successful
-                // Then I receive a successful response
-                XCTAssertNotNil(response)
-                XCTAssertNotNil(response?.items?.first)
-                XCTAssertEqual(response?.items?.first?.result, TransactionResult.success)
+                XCTFail("API call failed with error: \(error)")
             }
+            
+            XCTAssertNotNil(response,
+                            "Response must not be nil on valid receipt")
+            
+            XCTAssertNotNil(response?.items?.first,
+                            "Response must contain at least one JPTransactionData object")
+            
+            XCTAssertEqual(response?.items?.first?.result, TransactionResult.success,
+                           "Response should return a succesful transaction result")
+            
             expectation.fulfill()
         })
 


### PR DESCRIPTION
- Fixed, formatted and re-enabled Register Card Tests
- Formatted and fixed Receipt and Refund Tests [still disabled due to API permission issues];