### PR TITLE
Canada Postal Code Fix

### DIFF
--- a/JudoKitObjC.xcodeproj/project.pbxproj
+++ b/JudoKitObjC.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		44E3A10723498B770042C9EC /* Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = 44E3A10623498B770042C9EC /* Settings.m */; };
 		44E3A10A23498D150042C9EC /* HalfHeightPresentationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 44E3A10923498D150042C9EC /* HalfHeightPresentationController.m */; };
 		44FFE3A722F04FD100E42F2D /* TransactionEnricherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FFE3A622F04FD000E42F2D /* TransactionEnricherTests.swift */; };
+		526B4C8E23678300002C5B79 /* PostCodeValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526B4C8C236782E8002C5B79 /* PostCodeValidationTests.swift */; };
 		701050BB1E1E90FB0001ED87 /* DeviceDNA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 701050BA1E1E90FB0001ED87 /* DeviceDNA.framework */; };
 		701050BC1E1E91040001ED87 /* DeviceDNA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 701050BA1E1E90FB0001ED87 /* DeviceDNA.framework */; };
 		701050BD1E1E91040001ED87 /* DeviceDNA.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 701050BA1E1E90FB0001ED87 /* DeviceDNA.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -547,6 +548,7 @@
 		44E3A10823498D150042C9EC /* HalfHeightPresentationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HalfHeightPresentationController.h; sourceTree = "<group>"; };
 		44E3A10923498D150042C9EC /* HalfHeightPresentationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HalfHeightPresentationController.m; sourceTree = "<group>"; };
 		44FFE3A622F04FD000E42F2D /* TransactionEnricherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionEnricherTests.swift; sourceTree = "<group>"; };
+		526B4C8C236782E8002C5B79 /* PostCodeValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCodeValidationTests.swift; sourceTree = "<group>"; };
 		701050BA1E1E90FB0001ED87 /* DeviceDNA.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DeviceDNA.framework; path = DeviceDNA/Framework/DeviceDNA.framework; sourceTree = "<group>"; };
 		702804271CE3873A00150B21 /* JudoTestCaseConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JudoTestCaseConfig.swift; sourceTree = "<group>"; };
 		702804351CE9C96D00150B21 /* CardDetailsSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardDetailsSetTests.swift; sourceTree = "<group>"; };
@@ -974,6 +976,7 @@
 				3B4EB3F21C982A25006265A0 /* TransactionTests.swift */,
 				15CFC9EC1FB74A4200430D31 /* VCOTests.swift */,
 				3B4EB3F31C982A25006265A0 /* VoidTransactionTests.swift */,
+				526B4C8C236782E8002C5B79 /* PostCodeValidationTests.swift */,
 			);
 			path = APITests;
 			sourceTree = "<group>";
@@ -1226,7 +1229,7 @@
 					3B678B551C6CE5190001DC2F = {
 						CreatedOnToolsVersion = 7.2;
 						DevelopmentTeam = 2354U295GD;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					3B678B5F1C6CE5190001DC2F = {
@@ -1534,6 +1537,7 @@
 				3B4EB3F61C982A25006265A0 /* JudoTestCase.swift in Sources */,
 				3B4EB3F81C982A25006265A0 /* ListTests.swift in Sources */,
 				3B4EB3F91C982A25006265A0 /* PaymentTests.swift in Sources */,
+				526B4C8E23678300002C5B79 /* PostCodeValidationTests.swift in Sources */,
 				3B4EB4001C982A25006265A0 /* TokenPreAuthTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/View/InputFields/PostCodeInputField.m
+++ b/Source/View/InputFields/PostCodeInputField.m
@@ -103,9 +103,6 @@ static NSString *const kUSARegexString = @"(^\\d{5}$)|(^\\d{5}-\\d{4}$)";
 }
 
 - (BOOL)isValid {
-    if (self.billingCountry == BillingCountryOther) {
-        return YES;
-    }
 
     NSString *newString = [self.textField.text uppercaseString];
 
@@ -142,7 +139,7 @@ static NSString *const kUSARegexString = @"(^\\d{5}$)|(^\\d{5}-\\d{4}$)";
         valid = NO;
     }
 
-    if (self.billingCountry == BillingCountryCanada && characterCount >= 6) {
+    if (self.billingCountry == BillingCountryCanada && characterCount >= 6 && !self.isValid) {
         valid = NO;
     }
 

--- a/Tests/APITests/PostCodeValidationTests.swift
+++ b/Tests/APITests/PostCodeValidationTests.swift
@@ -1,0 +1,85 @@
+//
+//  PostCodeValidationTests.swift
+//  JudoKitObjCTests
+//
+//  Copyright (c) 2019 Alternative Payments Ltd
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import XCTest
+@testable import JudoKitObjC
+
+class PostCodeValidationTests: XCTestCase {
+    
+    func test_OnValidUKPostcode_ReturnTrue() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.UK
+        postcodeInputField.textField.text = "FK208QT"
+        XCTAssertTrue(postcodeInputField.isValid)
+    }
+    
+    func test_OnInvalidUKPostcode_ReturnFalse() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.UK
+        postcodeInputField.textField.text = "ABCDEF"
+        XCTAssertFalse(postcodeInputField.isValid)
+    }
+    
+    func test_OnValidCanadaPostcode_ReturnTrue() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.canada
+        postcodeInputField.textField.text = "K1A0B1"
+        XCTAssertTrue(postcodeInputField.isValid)
+    }
+    
+    func test_OnInvalidCanadaPostcode_ReturnFalse() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.canada
+        postcodeInputField.textField.text = "Z1AD11"
+        XCTAssertFalse(postcodeInputField.isValid)
+    }
+    
+    func test_OnValidUSPostcode_ReturnTrue() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.USA
+        postcodeInputField.textField.text = "85055"
+        XCTAssertTrue(postcodeInputField.isValid)
+    }
+    
+    func test_OnInvalidUSPostcode_ReturnFalse() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.USA
+        postcodeInputField.textField.text = "ABC123"
+        XCTAssertFalse(postcodeInputField.isValid)
+    }
+    
+    func test_OnValidOtherPostcode_ReturnTrue() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.other
+        postcodeInputField.textField.text = "123456"
+        XCTAssertTrue(postcodeInputField.isValid)
+    }
+    
+    func test_OnInvalidOtherPostcode_ReturnFalse() {
+        let postcodeInputField = PostCodeInputField()
+        postcodeInputField.billingCountry = BillingCountry.other
+        postcodeInputField.textField.text = "A12345"
+        XCTAssertFalse(postcodeInputField.isValid)
+    }
+}


### PR DESCRIPTION
- Fixed postal code validation for Canada;
- Added unit tests for postal code validation;
- Removed the automatic `return YES` for postal code validation if BillingCountry is set to Other due to redundancy.  It is now handled by the default switch statement;

> **Note:** BillingCountry is validated only if numeric and less than 8 characters, instead of the automatic YES it had before. Might cause issues and would probably be better to remove the numeric condition altogether.