### PR TITLE
Completed the iDEAL flow

### DIFF
--- a/JudoKitObjCExampleApp/Controllers/MainViewController.m
+++ b/JudoKitObjCExampleApp/Controllers/MainViewController.m
@@ -408,7 +408,7 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
 - (void)idealTransactionOperation {
     
     [self.judoKitSession invokeIDEALPaymentWithJudoId:judoId
-                                               amount:[[JPAmount alloc] initWithAmount:@"0.01" currency:@"GBP"]
+                                               amount:0.01
                                             reference:[JPReference consumerReference:self.reference]
                                              delegate:self
                                            completion:^(JPResponse *response, NSError *error) {

--- a/Source/API/JPReceipt.m
+++ b/Source/API/JPReceipt.m
@@ -52,13 +52,15 @@
         path = [path stringByAppendingString:self.receiptId];
     }
 
-    [self.apiSession GET:path parameters:nil completion:completion];
+    NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.apiSession.endpoint, path];
+    [self.apiSession GET:fullURL parameters:nil completion:completion];
 }
 
 - (void)listWithPagination:(JPPagination *)pagination completion:(void (^)(JPResponse *, NSError *))completion {
     NSString *path = [NSString stringWithFormat:@"transactions?pageSize=%li&offset=%li&sort=%@", (long)pagination.pageSize, (long)pagination.offset, pagination.sort];
 
-    [self.apiSession GET:path parameters:nil completion:completion];
+    NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.apiSession.endpoint, path];
+    [self.apiSession GET:fullURL parameters:nil completion:completion];
 }
 
 @end

--- a/Source/API/JPSession.h
+++ b/Source/API/JPSession.h
@@ -39,6 +39,11 @@ typedef void (^JudoCompletionBlock)(JPResponse *_Nullable, NSError *_Nullable);
 @property (nonatomic, strong, readonly) NSString *_Nonnull endpoint;
 
 /**
+ *  The endpoint for REST API calls to the judo API related to iDEAL transactions
+ */
+@property (nonatomic, strong, readonly) NSString *_Nonnull iDealEndpoint;
+
+/**
  *  Token and secret are saved in the authorizationHeader for authentication of REST API calls
  */
 @property (nonatomic, strong, readonly) NSString *_Nullable authorizationHeader;

--- a/Source/API/JPSession.m
+++ b/Source/API/JPSession.m
@@ -91,6 +91,8 @@ static NSString *const HTTPMethodPUT = @"PUT";
     NSURL *requestURL = [NSURL URLWithString:self.endpoint];
     self.reachability = [JPReachability reachabilityWithURL:requestURL];
 
+    _iDealEndpoint = @"https://api.judopay.com/";
+    
     return self;
 }
 
@@ -116,8 +118,7 @@ static NSString *const HTTPMethodPUT = @"PUT";
                       parameters:(NSDictionary *)parameters
                       completion:(JudoCompletionBlock)completion {
 
-    NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.endpoint, path];
-    NSMutableURLRequest *request = [self judoRequest:fullURL];
+    NSMutableURLRequest *request = [self judoRequest:path];
 
     request.HTTPMethod = HTTPMethod;
 

--- a/Source/API/JPSession.m
+++ b/Source/API/JPSession.m
@@ -92,7 +92,7 @@ static NSString *const HTTPMethodPUT = @"PUT";
     self.reachability = [JPReachability reachabilityWithURL:requestURL];
 
     _iDealEndpoint = @"https://api.judopay.com/";
-    
+
     return self;
 }
 

--- a/Source/API/JPTransaction.m
+++ b/Source/API/JPTransaction.m
@@ -82,9 +82,9 @@
     }
 
     self.currentTransactionReference = self.reference.paymentReference;
-    
+
     NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.apiSession.endpoint, self.transactionPath];
-    
+
     [self.enricher enrichTransaction:self
                       withCompletion:^{
                           [self.apiSession POST:fullURL parameters:self.parameters completion:completion];
@@ -116,9 +116,9 @@
 }
 
 - (void)threeDSecureWithParameters:(NSDictionary *)parameters receiptId:(NSString *)receiptId completion:(JudoCompletionBlock)completion {
-    
+
     NSString *fullURL = [NSString stringWithFormat:@"%@transactions/%@", self.apiSession.endpoint, receiptId];
-    
+
     [self.apiSession PUT:fullURL
               parameters:parameters
               completion:completion];

--- a/Source/API/JPTransaction.m
+++ b/Source/API/JPTransaction.m
@@ -82,10 +82,12 @@
     }
 
     self.currentTransactionReference = self.reference.paymentReference;
-
+    
+    NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.apiSession.endpoint, self.transactionPath];
+    
     [self.enricher enrichTransaction:self
                       withCompletion:^{
-                          [self.apiSession POST:self.transactionPath parameters:self.parameters completion:completion];
+                          [self.apiSession POST:fullURL parameters:self.parameters completion:completion];
                       }];
 }
 
@@ -114,7 +116,10 @@
 }
 
 - (void)threeDSecureWithParameters:(NSDictionary *)parameters receiptId:(NSString *)receiptId completion:(JudoCompletionBlock)completion {
-    [self.apiSession PUT:[NSString stringWithFormat:@"transactions/%@", receiptId]
+    
+    NSString *fullURL = [NSString stringWithFormat:@"%@transactions/%@", self.apiSession.endpoint, receiptId];
+    
+    [self.apiSession PUT:fullURL
               parameters:parameters
               completion:completion];
 }
@@ -128,7 +133,8 @@
     if (pagination) {
         path = [path stringByAppendingFormat:@"?pageSize=%li&offset=%li&sort=%@", (long)pagination.pageSize, (long)pagination.offset, pagination.sort];
     }
-    [self.apiSession GET:path parameters:nil completion:completion];
+    NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.apiSession.endpoint, path];
+    [self.apiSession GET:fullURL parameters:nil completion:completion];
 }
 
 #pragma mark - getters and setters

--- a/Source/API/JPTransactionProcess.m
+++ b/Source/API/JPTransactionProcess.m
@@ -50,7 +50,8 @@
 }
 
 - (void)sendWithCompletion:(void (^)(JPResponse *, NSError *))completion {
-    [self.apiSession POST:self.transactionProcessingPath parameters:self.parameters completion:completion];
+    NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.apiSession.endpoint, self.transactionProcessingPath];
+    [self.apiSession POST:fullURL parameters:self.parameters completion:completion];
 }
 
 #pragma mark - getters

--- a/Source/Controller/JudoPaymentMethodsViewController.m
+++ b/Source/Controller/JudoPaymentMethodsViewController.m
@@ -25,6 +25,7 @@
 #import "JudoPaymentMethodsViewController.h"
 #import <PassKit/PassKit.h>
 
+#import "JPAmount.h"
 #import "JPResponse.h"
 #import "JPSession.h"
 #import "JPTheme.h"
@@ -247,7 +248,7 @@
     __weak JudoPaymentMethodsViewController *weakSelf = self;
 
     [self.judoKitSession invokeIDEALPaymentWithJudoId:self.viewModel.judoId
-                                               amount:self.viewModel.amount
+                                               amount:self.viewModel.amount.amount.doubleValue
                                             reference:self.viewModel.reference
                                              delegate:self.idealDelegate
                                            completion:^(JPResponse *response, NSError *error) {

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -471,13 +471,13 @@ static NSString *__nonnull const JudoKitVersion = @"8.0.1";
  *  merchant to set a name and select from one of the available iDEAL banks to complete the transaction.
  *
  *  @param judoId           The judoID of the merchant to receive the token pre-auth
- *  @param amount           The amount and currency of the pre-auth (default is GBP)
+ *  @param amount           The amount expressed as a double (currency is limited to EUR)
  *  @param reference     Holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information up to 1024 characters
  *  @param delegate       An optional delegate parameter that, once implemented, will allow you to capture the IDEAL redirect response data
  *  @param completion   The completion handler which will respond with a JPResponse object or an NSError
  */
 - (void)invokeIDEALPaymentWithJudoId:(nonnull NSString *)judoId
-                              amount:(nonnull JPAmount *)amount
+                              amount:(double)amount
                            reference:(nonnull JPReference *)reference
                             delegate:(nullable id<IDEALServiceDelegate>)delegate
                           completion:(nonnull JudoCompletionBlock)completion;

--- a/Source/JudoKit.m
+++ b/Source/JudoKit.m
@@ -549,7 +549,7 @@
 }
 
 - (void)invokeIDEALPaymentWithJudoId:(NSString *)judoId
-                              amount:(JPAmount *)amount
+                              amount:(double)amount
                            reference:(JPReference *)reference
                             delegate:(id<IDEALServiceDelegate>)delegate
                           completion:(JudoCompletionBlock)completion {

--- a/Source/Managers/IDEALService.h
+++ b/Source/Managers/IDEALService.h
@@ -42,19 +42,27 @@ typedef NS_ENUM(NSUInteger, IDEALStatus) {
 typedef void (^JudoRedirectCompletion)(NSString *_Nullable, NSString *_Nullable, NSError *_Nullable);
 typedef void (^JudoPollingCompletion)(IDEALStatus, NSError *_Nullable);
 
+/**
+ * A string describing the account holder name
+ */
+@property (nonatomic, strong) NSString *_Nullable accountHolderName;
+
+/**
+ * An reference to the IDEALServiceDelegate adopting object
+ */
 @property (nonatomic, weak) id<IDEALServiceDelegate> _Nullable delegate;
 
 /**
  * Creates an instance of an IDEALService object
  *
- * @param judoId           The judoID of the merchant to receive the token pre-auth
- * @param amount           The amount and currency of the pre-auth (default is GBP)
+ * @param judoId           The Judo ID of the merchant to receive the iDeal transaction
+ * @param amount           The amount expressed as a double value (currency is always EUR)
  * @param reference    Holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information up to 1024 characters
  * @param session         An instance of JPSession that is used to make API requests
  * @param paymentMetadata                       Freeformat optional JSON metadata
  */
 - (nonnull instancetype)initWithJudoId:(nonnull NSString *)judoId
-                                amount:(nonnull JPAmount *)amount
+                                amount:(double)amount
                              reference:(nonnull JPReference *)reference
                                session:(nonnull JPSession *)session
                        paymentMetadata:(nullable NSDictionary *)paymentMetadata;
@@ -78,5 +86,10 @@ typedef void (^JudoPollingCompletion)(IDEALStatus, NSError *_Nullable);
 - (void)pollTransactionStatusForOrderId:(nonnull NSString *)orderId
                                checksum:(nonnull NSString *)checksum
                              completion:(nonnull JudoCompletionBlock)completion;
+
+/**
+ * Method used to invalidate the timer and stop the polling process
+*/
+- (void)stopPollingTransactionStatus;
 
 @end

--- a/Source/Managers/IDEALService.m
+++ b/Source/Managers/IDEALService.m
@@ -70,7 +70,7 @@ static NSString *statusEndpoint = @"order/bank/statusrequest";
                      completion:(JudoRedirectCompletion)completion {
 
     NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.session.iDealEndpoint, redirectEndpoint];
-    
+
     [self.session POST:fullURL
             parameters:[self parametersForIDEALBank:iDealBank]
             completion:^(JPResponse *response, NSError *error) {
@@ -105,10 +105,11 @@ static NSString *statusEndpoint = @"order/bank/statusrequest";
                    checksum:(NSString *)checksum
                  completion:(JudoCompletionBlock)completion {
 
-    if (self.didTimeout) return;
-     
+    if (self.didTimeout)
+        return;
+
     NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.session.iDealEndpoint, statusEndpoint];
-    
+
     [self.session POST:fullURL
             parameters:[self pollingParametersForOrderID:orderId checksum:checksum]
             completion:^(JPResponse *response, NSError *error) {
@@ -141,7 +142,7 @@ static NSString *statusEndpoint = @"order/bank/statusrequest";
 
     NSNumber *amount = [NSNumber numberWithDouble:self.amount];
     NSString *trimmedPaymentReference = [self.reference.paymentReference substringToIndex:39];
-    
+
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
         @"paymentMethod" : @"IDEAL",
         @"currency" : @"EUR",
@@ -163,22 +164,22 @@ static NSString *statusEndpoint = @"order/bank/statusrequest";
 
 - (NSDictionary *)pollingParametersForOrderID:(NSString *)orderId
                                      checksum:(NSString *)checksum {
-    
+
     NSString *trimmedPaymentReference = [self.reference.paymentReference substringToIndex:39];
-    
-    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary: @{
-         @"paymentMethod": @"IDEAL",
-         @"orderId": orderId,
-         @"siteId": self.judoId,
-         @"merchantPaymentReference": trimmedPaymentReference,
-         @"merchantConsumerReference": self.reference.consumerReference,
-         @"checksum": checksum
+
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
+        @"paymentMethod" : @"IDEAL",
+        @"orderId" : orderId,
+        @"siteId" : self.judoId,
+        @"merchantPaymentReference" : trimmedPaymentReference,
+        @"merchantConsumerReference" : self.reference.consumerReference,
+        @"checksum" : checksum
     }];
-    
+
     if (self.paymentMetadata) {
         parameters[@"paymentMetadata"] = self.paymentMetadata;
     }
-    
+
     return parameters;
 }
 

--- a/Source/Theme/JPTheme.m
+++ b/Source/Theme/JPTheme.m
@@ -163,21 +163,21 @@
 
 - (NSString *)idealTransactionSuccessTitle {
     if (!_idealTransactionSuccessTitle) {
-        _idealTransactionSuccessTitle = @"ideal_status_success".localized;
+        _idealTransactionSuccessTitle = @"ideal_transaction_success".localized;
     }
     return _idealTransactionSuccessTitle;
 }
 
 - (NSString *)idealTransactionPendingTitle {
     if (!_idealTransactionPendingTitle) {
-        _idealTransactionPendingTitle = @"ideal_status_pending".localized;
+        _idealTransactionPendingTitle = @"ideal_transaction_pending".localized;
     }
     return _idealTransactionPendingTitle;
 }
 
 - (NSString *)idealTransactionFailedTitle {
     if (!_idealTransactionFailedTitle) {
-        _idealTransactionFailedTitle = @"ideal_status_failed".localized;
+        _idealTransactionFailedTitle = @"ideal_transaction_failed".localized;
     }
     return _idealTransactionFailedTitle;
 }
@@ -345,7 +345,7 @@
     if (_judoButtonTitleColor) {
         return _judoButtonTitleColor;
     }
-    return [self.tintColor isDarkColor] ? [UIColor whiteColor] : [UIColor blackColor];
+    return [self.tintColor isDarkColor] ? [UIColor grayColor] : [UIColor whiteColor];
 }
 
 #pragma mark - Payment Methods

--- a/Source/iDEAL/IDEALFormViewController.h
+++ b/Source/iDEAL/IDEALFormViewController.h
@@ -39,9 +39,9 @@
 /**
  *  Initializer that displays the iDEAL transaction form
  *
- *  @param judoId                            The judoID of the merchant to receive the token pre-auth
+ *  @param judoId                            The judoID of the merchant to receive the iDeal transaction
  *  @param theme                              An instance of a JPTheme object that defines the style of the form
- *  @param amount                            The amount and currency of the pre-auth (default is GBP)
+ *  @param amount                            The amount expressed as a double value (currency is limited to EUR)
  *  @param reference                     Holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information up to 1024 characters
  *  @param session                          An instance of a JPSession object that is used for making API requests
  *  @param paymentMetadata        An optional parameter for additional metadata
@@ -52,7 +52,7 @@
  */
 - (nonnull instancetype)initWithJudoId:(nonnull NSString *)judoId
                                  theme:(nonnull JPTheme *)theme
-                                amount:(nonnull JPAmount *)amount
+                                amount:(double)amount
                              reference:(nonnull JPReference *)reference
                                session:(nonnull JPSession *)session
                        paymentMetadata:(nullable NSDictionary *)paymentMetadata

--- a/Source/iDEAL/IDEALFormViewController.m
+++ b/Source/iDEAL/IDEALFormViewController.m
@@ -73,7 +73,7 @@
 
 - (instancetype)initWithJudoId:(NSString *)judoId
                          theme:(JPTheme *)theme
-                        amount:(JPAmount *)amount
+                        amount:(double)amount
                      reference:(JPReference *)reference
                        session:(JPSession *)session
                paymentMetadata:(NSDictionary *)paymentMetadata
@@ -108,6 +108,7 @@
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [self.idealService stopPollingTransactionStatus];
     [self.nameInputField endEditing:YES];
     [self removeKeyboardObservers];
     [super viewWillDisappear:animated];
@@ -133,6 +134,7 @@
 
 - (void)onPayButtonTap:(id)sender {
 
+    self.idealService.accountHolderName = self.nameInputField.textField.text;
     [self.idealService redirectURLForIDEALBank:self.selectedBank
                                     completion:^(NSString *redirectUrl, NSString *orderId, NSError *error) {
                                         if (error) {


### PR DESCRIPTION
### Features:
- Integrated complete iDEAL payment flow with `api.judopay.com`;
- Added account holder name to the iDEAL request;

### Improvements:
- Limited the iDEAL currency to `EUR` as per requirements;
- Changed iDEAL amount to `double` as per requirements;
- Redone the REST methods to accept the full path and not the endpoint due to multiple origins;
- `merchantPaymentReference` has been trimmed to 40 characters as per requirements;

### Fixes:
- Fixed a small issue regarding polling not stoping on Back button press;
- Fixed wrong localization keys for the iDeal transaction status;