### PR TITLE
[EP-534] Added PreAuth option for the payment selection screen

### DIFF
--- a/JudoKitObjCExampleApp/Controllers/MainViewController.m
+++ b/JudoKitObjCExampleApp/Controllers/MainViewController.m
@@ -197,7 +197,7 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
         
     [self.judoKitSession invokePaymentMethodSelection:judoId
                                                amount:amount
-                                    consumerReference:self.reference
+                                            reference:[JPReference consumerReference:self.reference]
                                        paymentMethods:PaymentMethodsAll
                                            completion:^(JPResponse * response, NSError * error) {
                                     //Handle response / error
@@ -209,7 +209,7 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
         
     [self.judoKitSession invokePreAuthMethodSelection:judoId
                                                amount:amount
-                                    consumerReference:self.reference
+                                            reference:[JPReference consumerReference:self.reference]
                                        paymentMethods:PaymentMethodsAll
                                            completion:^(JPResponse * response, NSError * error) {
                                     //Handle response / error

--- a/JudoKitObjCExampleApp/Controllers/MainViewController.m
+++ b/JudoKitObjCExampleApp/Controllers/MainViewController.m
@@ -169,6 +169,10 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
             [self paymentMethodOption];
             break;
             
+        case DemoFeatureTypePreAuthMethods:
+            [self preAuthMethodOption];
+            break;
+            
         case DemoFeatureTypeIDEALTransaction:
             [self idealTransactionOperation];
             break;
@@ -191,13 +195,25 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
 - (void)paymentMethodOption {
     JPAmount *amount = [[JPAmount alloc] initWithAmount:@"0.01" currency:self.settings.currency];
         
-    [self.judoKitSession invokePayment:judoId
-                                amount:amount
-                     consumerReference:self.reference
-                        paymentMethods:PaymentMethodsAll
-                            completion:^(JPResponse * response, NSError * error) {
-                                //Handle response / error
-                            }];
+    [self.judoKitSession invokePaymentMethodSelection:judoId
+                                               amount:amount
+                                    consumerReference:self.reference
+                                       paymentMethods:PaymentMethodsAll
+                                           completion:^(JPResponse * response, NSError * error) {
+                                    //Handle response / error
+                                }];
+}
+
+- (void)preAuthMethodOption {
+    JPAmount *amount = [[JPAmount alloc] initWithAmount:@"0.01" currency:self.settings.currency];
+        
+    [self.judoKitSession invokePreAuthMethodSelection:judoId
+                                               amount:amount
+                                    consumerReference:self.reference
+                                       paymentMethods:PaymentMethodsAll
+                                           completion:^(JPResponse * response, NSError * error) {
+                                    //Handle response / error
+                                }];
 }
 
 - (void)paymentOperation {

--- a/JudoKitObjCExampleApp/Models/DemoFeature.h
+++ b/JudoKitObjCExampleApp/Models/DemoFeature.h
@@ -13,6 +13,7 @@ typedef NS_ENUM(NSUInteger, DemoFeatureType) {
     DemoFeatureTypeApplePayPayment,
     DemoFeatureTypeApplePayPreAuth,
     DemoFeatureTypePaymentMethods,
+    DemoFeatureTypePreAuthMethods,
     DemoFeatureTypeIDEALTransaction,
     DemoFeatureTypeStandaloneApplePayButton
 };

--- a/JudoKitObjCExampleApp/Models/DemoFeature.m
+++ b/JudoKitObjCExampleApp/Models/DemoFeature.m
@@ -23,6 +23,7 @@
         [DemoFeature featureWithType:DemoFeatureTypeApplePayPayment title:@"Apple Pay payment" details: @"with a wallet card"],
         [DemoFeature featureWithType:DemoFeatureTypeApplePayPreAuth title:@"Apple Pay preAuth" details: @"with a wallet card"],
         [DemoFeature featureWithType:DemoFeatureTypePaymentMethods title: @"Payment Method" details: @"with default payment methods"],
+        [DemoFeature featureWithType:DemoFeatureTypePreAuthMethods title:@"PreAuth Methods" details:@"with default preauth methods"],
         [DemoFeature featureWithType:DemoFeatureTypeIDEALTransaction title:@"iDEAL Transaction" details:@"for custom bank transactions"],
         [DemoFeature featureWithType:DemoFeatureTypeStandaloneApplePayButton title: @"Apple Pay Button" details: @"Standalone ApplePay Button"]
     ];

--- a/JudoKitObjCExampleAppUITests/JudoKitPaymentMethodsTests.swift
+++ b/JudoKitObjCExampleAppUITests/JudoKitPaymentMethodsTests.swift
@@ -51,7 +51,7 @@ class JudoKitPaymentMethodsTests: XCTestCase {
         app.tables.staticTexts["Payment Method"].tap();
         app.buttons["ADD CARD"].tap();
         
-        enterCardDetails()
+        enterCardDetails(with: "4976 0000 0000 3436")
         
         XCTAssertTrue(app.staticTexts["Card for shopping"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Visa Ending 1111"].waitForExistence(timeout: 5))
@@ -66,7 +66,7 @@ class JudoKitPaymentMethodsTests: XCTestCase {
         app.tables.staticTexts["Payment Method"].tap();
         app.buttons["ADD CARD"].tap();
         
-        enterCardDetails()
+        enterCardDetails(with: "4976 0000 0000 3436")
         
         app.cells.staticTexts["Card for shopping"].firstMatch.tap()
         
@@ -74,22 +74,49 @@ class JudoKitPaymentMethodsTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["12/20"].waitForExistence(timeout: 3.0))
     }
     
-    func enterCardDetails() {
+    func test_OnSuccessfulPayment_DismissPaymentMethodScreen() {
+        
+        let app = XCUIApplication();
+        app.tables.staticTexts["Payment Method"].tap();
+        app.buttons["ADD CARD"].tap();
+        
+        enterCardDetails(with: "4976 0000 0000 3436")
+        
+        app.cells.staticTexts["Card for shopping"].firstMatch.tap()
+        app.buttons["PAY NOW"].tap();
+                
+        XCTAssertTrue(app.tables.staticTexts["Payment Method"].waitForExistence(timeout: 30))
+    }
+    
+    func test_OnFailedPayment_DisplayAlert() {
+        let app = XCUIApplication();
+        app.tables.staticTexts["Payment Method"].tap();
+        app.buttons["ADD CARD"].tap();
+        
+        enterCardDetails(with: "4111 1111 1111 1111")
+        
+        app.cells.staticTexts["Card for shopping"].firstMatch.tap()
+        app.buttons["PAY NOW"].tap();
+        
+        XCTAssertTrue(app.alerts.firstMatch.waitForExistence(timeout: 30))
+    }
+    
+    func enterCardDetails(with number:String) {
         
         let app = XCUIApplication()
         
         app.textFields["Card Number"].tap()
-        app.textFields["Card Number"].typeText("4111 1111 1111 1111")
+        app.textFields["Card Number"].typeText(number)
         
         app.textFields["Cardholder Name"].tap()
         app.textFields["Cardholder Name"].typeText("Hello")
         
         app.textFields["MM/YY"].tap()
-        app.textFields["MM/YY"].typeText("12/20")
+        app.textFields["MM/YY"].typeText("1220")
         
         app.textFields["CVV"].tap()
-        app.textFields["CVV"].typeText("341")
+        app.textFields["CVV"].typeText("452")
         
-        app.buttons["ADD CARD"].firstMatch.tap();
+        app.buttons["ADD CARD"].firstMatch.tap()
     }
 }

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "choose_payment_method" = "Choose a Payment Method";
 "no_cards_added"  = "You didn’t add any cards yet.\nAdd one right now or use any of the payment methods below";
 "you_will_pay" = "You will pay";
+"card_transaction_unsuccesful_error" = "Card transaction unsuccessful - please try again";
 
 //CardInputField
 "card_number_label" = "Card number";

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -139,6 +139,7 @@
 "error_timeout_description" = "Request did not complete in the specified time";
 "no_internet_error_description" = "Please check your internet connection and try again.";
 "no_internet_error_title" = "No internet connection!";
+"error_token_missing" = "The card token could not be retrieved from the response";
 
 //NSString+Card
 "check_card_number" = "Check card number";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "choose_payment_method" = "Choose a Payment Method";
 "no_cards_added"  = "You didn’t add any cards yet.\nAdd one right now or use any of the payment methods below";
 "you_will_pay" = "You will pay";
+"card_transaction_unsuccesful_error" = "Card transaction unsuccessful - please try again";
 
 //CardInputField
 "card_number_label" = "Card number";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -139,6 +139,7 @@
 "error_timeout_description" = "Request did not complete in the specified time";
 "no_internet_error_description" = "Please check your internet connection and try again.";
 "no_internet_error_title" = "No internet connection!";
+"error_token_missing" = "The card token could not be retrieved from the response";
 
 //NSString+Card
 "check_card_number" = "Check card number";

--- a/Resources/es.lproj/Localizable.strings
+++ b/Resources/es.lproj/Localizable.strings
@@ -140,6 +140,7 @@
 "error_timeout_description" = "La solicitud no se completó en el tiempo especificado";
 "no_internet_error_description" = "Verifique su conexión a Internet e intente nuevamente.";
 "no_internet_error_title" = "¡Sin conexión a Internet!";
+"error_token_missing" = "The card token could not be retrieved from the response";
 
 //NSString+Card
 "check_card_number" = "Comprobar número de tarjeta";

--- a/Resources/es.lproj/Localizable.strings
+++ b/Resources/es.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "choose_payment_method" = "Choose a Payment Method";
 "no_cards_added"  = "You didn’t add any cards yet.\nAdd one right now or use any of the payment methods below";
 "you_will_pay" = "You will pay";
+"card_transaction_unsuccesful_error" = "Card transaction unsuccessful - please try again";
 
 //CardInputField
 "card_number_label" = "Número de tarjeta";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "choose_payment_method" = "Choose a Payment Method";
 "no_cards_added"  = "You didn’t add any cards yet.\nAdd one right now or use any of the payment methods below";
 "you_will_pay" = "You will pay";
+"card_transaction_unsuccesful_error" = "Card transaction unsuccessful - please try again";
 
 //CardInputField
 "card_number_label" = "Card number";

--- a/Resources/fr.lproj/Localizable.strings
+++ b/Resources/fr.lproj/Localizable.strings
@@ -140,6 +140,7 @@
 "error_timeout_description" = "Request did not complete in the specified time";
 "no_internet_error_description" = "Please check your internet connection and try again.";
 "no_internet_error_title" = "No internet connection!";
+"error_token_missing" = "The card token could not be retrieved from the response";
 
 //NSString+Card
 "check_card_number" = "Check card number";

--- a/Resources/nl.lproj/Localizable.strings
+++ b/Resources/nl.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "choose_payment_method" = "Choose a Payment Method";
 "no_cards_added"  = "You didn’t add any cards yet.\nAdd one right now or use any of the payment methods below";
 "you_will_pay" = "You will pay";
+"card_transaction_unsuccesful_error" = "Card transaction unsuccessful - please try again";
 
 //CardInputField
 "card_number_label" = "Card number";

--- a/Resources/nl.lproj/Localizable.strings
+++ b/Resources/nl.lproj/Localizable.strings
@@ -139,6 +139,7 @@
 "error_timeout_description" = "Request did not complete in the specified time";
 "no_internet_error_description" = "Please check your internet connection and try again.";
 "no_internet_error_title" = "No internet connection!";
+"error_token_missing" = "The card token could not be retrieved from the response";
 
 //NSString+Card
 "check_card_number" = "Check card number";

--- a/Resources/pt-PT.lproj/Localizable.strings
+++ b/Resources/pt-PT.lproj/Localizable.strings
@@ -140,6 +140,7 @@
 "error_timeout_description" = "A solicitação não foi concluída no tempo especificado";
 "no_internet_error_description" = "Por favor verifique sua conexão com a internet e tente novamente.";
 "no_internet_error_title" = "Sem conexão à internet!";
+"error_token_missing" = "The card token could not be retrieved from the response";
 
 //NSString+Card
 "check_card_number" = "Confirmar número do cartão";

--- a/Resources/pt-PT.lproj/Localizable.strings
+++ b/Resources/pt-PT.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "choose_payment_method" = "Choose a Payment Method";
 "no_cards_added"  = "You didn’t add any cards yet.\nAdd one right now or use any of the payment methods below";
 "you_will_pay" = "You will pay";
+"card_transaction_unsuccesful_error" = "Card transaction unsuccessful - please try again";
 
 //CardInputField
 "card_number_label" = "Número do Cartão";

--- a/Source/Extensions/NSError+Judo.h
+++ b/Source/Extensions/NSError+Judo.h
@@ -38,6 +38,7 @@ extern NSString *const JudoErrorDomain;
 + (NSError *)judoPaymentMethodMissingError;
 + (NSError *)judoAmountMissingError;
 + (NSError *)judoReferenceMissingError;
++ (NSError *)judoTokenMissingError;
 + (NSError *)judoDuplicateTransactionError;
 + (NSError *)judo3DSRequestFailedErrorWithUnderlyingError:(nullable NSError *)underlyingError;
 + (NSError *)judoUserDidCancelError;
@@ -67,6 +68,7 @@ typedef NS_ENUM(NSUInteger, JudoError) {
     JudoErrorPaymentMethodMissing,
     JudoErrorAmountMissing,
     JudoErrorReferenceMissing,
+    JudoErrorTokenMissing,
     JudoErrorDuplicateTransaction,
     JudoError3DSRequest,
     JudoErrorUnderlyingError,

--- a/Source/Extensions/NSError+Judo.m
+++ b/Source/Extensions/NSError+Judo.m
@@ -37,6 +37,7 @@ NSString *const ErrorRequestFailed = @"error_request_failed";
 NSString *const ErrorPaymentMethodMissing = @"error_payment_method_missing";
 NSString *const ErrorAmountMissing = @"error_amount_missing";
 NSString *const ErrorReferenceMissing = @"error_reference_missing";
+NSString *const ErrorTokenMissing = @"error_token_missing";
 NSString *const ErrorResponseParseError = @"error_response_parse_error";
 NSString *const ErrorUserDidCancel = @"error_user_did_cancel";
 NSString *const ErrorParameterError = @"error_parameter_error";
@@ -106,6 +107,14 @@ NSString *const ErrorTransactionDeclined = @"error_transaction_declined";
                                code:JudoErrorReferenceMissing
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorReferenceMissing.localized
+                                                                title:UnableToProcessRequestErrorTitle.localized]];
+}
+
++ (NSError *)judoTokenMissingError {
+    return [NSError errorWithDomain:JudoErrorDomain
+                               code:JudoErrorTokenMissing
+                           userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
+                                                        failureReason:ErrorTokenMissing.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 

--- a/Source/Extensions/UIColor+Judo.h
+++ b/Source/Extensions/UIColor+Judo.h
@@ -50,16 +50,14 @@
 
 + (UIColor *_Nonnull)defaultTintColor;
 
-+ (UIColor *_Nonnull)jpErrorColor;
++ (UIColor *_Nonnull)jpBlackColor;
 
-+ (UIColor *_Nonnull)jpPlaceholderColor;
++ (UIColor *_Nonnull)jpRedColor;
 
-+ (UIColor *_Nonnull)jpTextColor;
++ (UIColor *_Nonnull)jpDarkGrayColor;
 
-+ (UIColor *_Nonnull)jpSubtitleColor;
++ (UIColor *_Nonnull)jpGrayColor;
 
-+ (UIColor *_Nonnull)jpTextFieldBackgroundColor;
-
-+ (UIColor *_Nonnull)jpContentBackgroundColor;
++ (UIColor *_Nonnull)jpLightGrayColor;
 
 @end

--- a/Source/Extensions/UIColor+Judo.m
+++ b/Source/Extensions/UIColor+Judo.m
@@ -106,28 +106,24 @@
     return [UIColor jellyBean];
 }
 
-+ (UIColor *)jpErrorColor {
-    return [UIColor colorFromHex:0xE21900];
-}
-
-+ (UIColor *)jpPlaceholderColor {
-    return [UIColor colorFromHex:0xE5E5E5];
-}
-
-+ (UIColor *)jpTextColor {
++ (UIColor *)jpBlackColor {
     return [UIColor colorFromHex:0x262626];
 }
 
-+ (UIColor *)jpSubtitleColor {
++ (UIColor *)jpDarkGrayColor {
     return [UIColor colorFromHex:0x999999];
 }
 
-+ (UIColor *)jpTextFieldBackgroundColor {
++ (UIColor *)jpGrayColor {
+    return [UIColor colorFromHex:0xE5E5E5];
+}
+
++ (UIColor *)jpLightGrayColor {
     return [UIColor colorFromHex:0xF6F6F6];
 }
 
-+ (UIColor *)jpContentBackgroundColor {
-    return [UIColor colorFromHex:0xEEEEEE];
++ (UIColor *)jpRedColor {
+    return [UIColor colorFromHex:0xE21900];
 }
 
 @end

--- a/Source/Extensions/UIViewController+Additions.h
+++ b/Source/Extensions/UIViewController+Additions.h
@@ -60,12 +60,17 @@
 - (void)displayAlertWithError:(NSError *)error;
 
 /**
+ * Method that triggers haptic feedback based on a specified feedback type
+ */
+- (void)triggerNotificationFeedbackWithType:(UINotificationFeedbackType)type;
+
+/**
  * Convenience method for displaying alert controllers based on a specified error with an optional title
  *
- * @param error - an NSError instance describing the current error
  * @param title - an optional NSString that defines the title of the alert
+ * @param error - an NSError instance describing the current error
  */
-- (void)displayAlertWithError:(NSError *)error andTitle:(NSString *)title;
+- (void)displayAlertWithTitle:(NSString *)title andError:(NSError *)error;
 
 /**
  * A convenience method for quickly registering keyboard observers

--- a/Source/Extensions/UIViewController+Additions.h
+++ b/Source/Extensions/UIViewController+Additions.h
@@ -60,6 +60,14 @@
 - (void)displayAlertWithError:(NSError *)error;
 
 /**
+ * Convenience method for displaying alert controllers based on a specified error with an optional title
+ *
+ * @param error - an NSError instance describing the current error
+ * @param title - an optional NSString that defines the title of the alert
+ */
+- (void)displayAlertWithError:(NSError *)error andTitle:(NSString *)title;
+
+/**
  * A convenience method for quickly registering keyboard observers
  */
 - (void)registerKeyboardObservers;

--- a/Source/Extensions/UIViewController+Additions.m
+++ b/Source/Extensions/UIViewController+Additions.m
@@ -54,14 +54,10 @@
 }
 
 - (void)displayAlertWithError:(NSError *)error {
-    [self displayAlertWithError:error andTitle:@"error".localized];
+    [self displayAlertWithTitle:@"error".localized andError:error];
 }
 
-- (void)displayAlertWithError:(NSError *)error andTitle:(NSString *)title {
-    
-    UINotificationFeedbackGenerator *feedbackGenerator = [UINotificationFeedbackGenerator new];
-    [feedbackGenerator notificationOccurred:UINotificationFeedbackTypeError];
-    
+- (void)displayAlertWithTitle:(NSString *)title andError:(NSError *)error {
     UIAlertController *controller = [UIAlertController alertControllerWithTitle:title
                                                                         message:error.localizedDescription
                                                                  preferredStyle:UIAlertControllerStyleAlert];
@@ -71,6 +67,11 @@
                                                      handler:nil];
     [controller addAction:okAction];
     [self presentViewController:controller animated:YES completion:nil];
+}
+
+- (void)triggerNotificationFeedbackWithType:(UINotificationFeedbackType)type {
+    UINotificationFeedbackGenerator *feedbackGenerator = [UINotificationFeedbackGenerator new];
+    [feedbackGenerator notificationOccurred:type];
 }
 
 - (void)registerKeyboardObservers {

--- a/Source/Extensions/UIViewController+Additions.m
+++ b/Source/Extensions/UIViewController+Additions.m
@@ -58,6 +58,10 @@
 }
 
 - (void)displayAlertWithError:(NSError *)error andTitle:(NSString *)title {
+    
+    UINotificationFeedbackGenerator *feedbackGenerator = [UINotificationFeedbackGenerator new];
+    [feedbackGenerator notificationOccurred:UINotificationFeedbackTypeError];
+    
     UIAlertController *controller = [UIAlertController alertControllerWithTitle:title
                                                                         message:error.localizedDescription
                                                                  preferredStyle:UIAlertControllerStyleAlert];

--- a/Source/Extensions/UIViewController+Additions.m
+++ b/Source/Extensions/UIViewController+Additions.m
@@ -54,7 +54,11 @@
 }
 
 - (void)displayAlertWithError:(NSError *)error {
-    UIAlertController *controller = [UIAlertController alertControllerWithTitle:@"error".localized
+    [self displayAlertWithError:error andTitle:@"error".localized];
+}
+
+- (void)displayAlertWithError:(NSError *)error andTitle:(NSString *)title {
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title
                                                                         message:error.localizedDescription
                                                                  preferredStyle:UIAlertControllerStyleAlert];
 

--- a/Source/JPCardView.m
+++ b/Source/JPCardView.m
@@ -132,7 +132,7 @@
         _titleLabel = [UILabel new];
         _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _titleLabel.font = UIFont.title;
-        _titleLabel.textColor = UIColor.jpTextColor;
+        _titleLabel.textColor = UIColor.jpBlackColor;
     }
     return _titleLabel;
 }
@@ -142,7 +142,7 @@
         _cardNumberLabel = [UILabel new];
         _cardNumberLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _cardNumberLabel.font = UIFont.bodyBold;
-        _cardNumberLabel.textColor = UIColor.jpSubtitleColor;
+        _cardNumberLabel.textColor = UIColor.jpDarkGrayColor;
     }
     return _cardNumberLabel;
 }
@@ -153,7 +153,7 @@
         _expiryDateLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _expiryDateLabel.textAlignment = NSTextAlignmentRight;
         _expiryDateLabel.font = UIFont.bodyBold;
-        _expiryDateLabel.textColor = UIColor.jpSubtitleColor;
+        _expiryDateLabel.textColor = UIColor.jpDarkGrayColor;
     }
     return _expiryDateLabel;
 }

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -257,13 +257,13 @@ static NSString *__nonnull const JudoKitVersion = @"8.2.1";
  *
  *  @param judoId               The judoID of the merchant to receive the payment
  *  @param amount               The amount and currency of the payment (default is GBP)
- *  @param reference            The consumer reference for this transaction
+ *  @param reference         The reference for this transaction
  *  @param methods              The payment methods to be shown
  *  @param completion           The completion handler which will respond with a JPResponse object or an NSError
  */
 - (void)invokePaymentMethodSelection:(nonnull NSString *)judoId
                               amount:(nonnull JPAmount *)amount
-                   consumerReference:(nonnull NSString *)reference
+                           reference:(nonnull JPReference *)reference
                       paymentMethods:(PaymentMethods)methods
                           completion:(nonnull JudoCompletionBlock)completion;
 
@@ -272,13 +272,13 @@ static NSString *__nonnull const JudoKitVersion = @"8.2.1";
  *
  *  @param judoId               The judoID of the merchant to receive the payment
  *  @param amount               The amount and currency of the payment (default is GBP)
- *  @param reference            The consumer reference for this transaction
+ *  @param reference            The reference for this transaction
  *  @param methods              The payment methods to be shown
  *  @param completion           The completion handler which will respond with a JPResponse object or an NSError
  */
 - (void)invokePreAuthMethodSelection:(nonnull NSString *)judoId
                               amount:(nonnull JPAmount *)amount
-                   consumerReference:(nonnull NSString *)reference
+                           reference:(nonnull JPReference *)reference
                       paymentMethods:(PaymentMethods)methods
                           completion:(nonnull JudoCompletionBlock)completion;
 

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -253,7 +253,7 @@ static NSString *__nonnull const JudoKitVersion = @"8.2.1";
 @interface JudoKit (Invokers)
 
 /**
- *  This method will invoke the Judo UI on the top UIViewController instance of the Application window. When the payment will finish or any errors encountered the completion block will be invoked with related details.
+ *  This method will invoke the Payment Method screen which allows you to select your preferred payment method to complete a Payment transaction.
  *
  *  @param judoId               The judoID of the merchant to receive the payment
  *  @param amount               The amount and currency of the payment (default is GBP)
@@ -261,11 +261,26 @@ static NSString *__nonnull const JudoKitVersion = @"8.2.1";
  *  @param methods              The payment methods to be shown
  *  @param completion           The completion handler which will respond with a JPResponse object or an NSError
  */
-- (void)invokePayment:(nonnull NSString *)judoId
-               amount:(nonnull JPAmount *)amount
-    consumerReference:(nonnull NSString *)reference
-       paymentMethods:(PaymentMethods)methods
-           completion:(nonnull JudoCompletionBlock)completion;
+- (void)invokePaymentMethodSelection:(nonnull NSString *)judoId
+                              amount:(nonnull JPAmount *)amount
+                   consumerReference:(nonnull NSString *)reference
+                      paymentMethods:(PaymentMethods)methods
+                          completion:(nonnull JudoCompletionBlock)completion;
+
+/**
+ *  This method will invoke the Payment Method screen which allows you to select your preferred payment method to complete a PreAuth transaction.
+ *
+ *  @param judoId               The judoID of the merchant to receive the payment
+ *  @param amount               The amount and currency of the payment (default is GBP)
+ *  @param reference            The consumer reference for this transaction
+ *  @param methods              The payment methods to be shown
+ *  @param completion           The completion handler which will respond with a JPResponse object or an NSError
+ */
+- (void)invokePreAuthMethodSelection:(nonnull NSString *)judoId
+                              amount:(nonnull JPAmount *)amount
+                   consumerReference:(nonnull NSString *)reference
+                      paymentMethods:(PaymentMethods)methods
+                          completion:(nonnull JudoCompletionBlock)completion;
 
 /**
  *  This method will invoke the Judo UI on the top UIViewController instance of the Application window. When the form has been successfully filled, the button will invoke a payment with the judo API and respond in a completion block

--- a/Source/JudoKit.m
+++ b/Source/JudoKit.m
@@ -338,7 +338,7 @@
 
 - (void)invokePaymentMethodSelection:(nonnull NSString *)judoId
                               amount:(nonnull JPAmount *)amount
-                   consumerReference:(nonnull NSString *)reference
+                           reference:(nonnull JPReference *)reference
                       paymentMethods:(PaymentMethods)methods
                           completion:(nonnull JudoCompletionBlock)completion {
 
@@ -347,7 +347,7 @@
                                                                              session:self
                                                                transitioningDelegate:self.transitioningDelegate
                                                                               amount:amount
-                                                                   consumerReference:reference
+                                                                           reference:reference
                                                                    completionHandler:completion];
 
     UINavigationController *navigationController;
@@ -360,7 +360,7 @@
 
 - (void)invokePreAuthMethodSelection:(nonnull NSString *)judoId
                               amount:(nonnull JPAmount *)amount
-                   consumerReference:(nonnull NSString *)reference
+                           reference:(nonnull JPReference *)reference
                       paymentMethods:(PaymentMethods)methods
                           completion:(nonnull JudoCompletionBlock)completion {
 
@@ -369,7 +369,7 @@
                                                                              session:self
                                                                transitioningDelegate:self.transitioningDelegate
                                                                               amount:amount
-                                                                   consumerReference:reference
+                                                                           reference:reference
                                                                    completionHandler:completion];
 
     UINavigationController *navigationController;

--- a/Source/JudoKit.m
+++ b/Source/JudoKit.m
@@ -336,19 +336,41 @@
 
 @implementation JudoKit (Invokers)
 
-- (void)invokePayment:(nonnull NSString *)judoId
-               amount:(nonnull JPAmount *)amount
-    consumerReference:(nonnull NSString *)reference
-       paymentMethods:(PaymentMethods)methods
-           completion:(nonnull JudoCompletionBlock)completion {
+- (void)invokePaymentMethodSelection:(nonnull NSString *)judoId
+                              amount:(nonnull JPAmount *)amount
+                   consumerReference:(nonnull NSString *)reference
+                      paymentMethods:(PaymentMethods)methods
+                          completion:(nonnull JudoCompletionBlock)completion {
 
     JPPaymentMethodsViewController *viewController;
-    viewController = [[JPPaymentMethodsBuilderImpl new] buildModuleWithJudoID:judoId
-                                                                      session:self
-                                                        transitioningDelegate:self.transitioningDelegate
-                                                                       amount:amount
-                                                            consumerReference:reference
-                                                            completionHandler:completion];
+    viewController = [[JPPaymentMethodsBuilderImpl new] buildPaymentModuleWithJudoID:judoId
+                                                                             session:self
+                                                               transitioningDelegate:self.transitioningDelegate
+                                                                              amount:amount
+                                                                   consumerReference:reference
+                                                                   completionHandler:completion];
+
+    UINavigationController *navigationController;
+    navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
+
+    self.activeViewController = viewController;
+    [self.topMostViewController presentViewController:navigationController animated:YES completion:nil];
+}
+
+- (void)invokePreAuthMethodSelection:(nonnull NSString *)judoId
+                              amount:(nonnull JPAmount *)amount
+                   consumerReference:(nonnull NSString *)reference
+                      paymentMethods:(PaymentMethods)methods
+                          completion:(nonnull JudoCompletionBlock)completion {
+
+    JPPaymentMethodsViewController *viewController;
+    viewController = [[JPPaymentMethodsBuilderImpl new] buildPreAuthModuleWithJudoID:judoId
+                                                                             session:self
+                                                               transitioningDelegate:self.transitioningDelegate
+                                                                              amount:amount
+                                                                   consumerReference:reference
+                                                                   completionHandler:completion];
 
     UINavigationController *navigationController;
     navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];

--- a/Source/Modules/AddCard/Presenter/JPAddCardPresenter.m
+++ b/Source/Modules/AddCard/Presenter/JPAddCardPresenter.m
@@ -114,7 +114,7 @@
                    return;
                }
 
-               NSString *token = response.items[0].cardDetails.cardToken;
+               NSString *token = response.items.firstObject.cardDetails.cardToken;
 
                [weakSelf.interactor updateKeychainWithCardModel:weakSelf.addCardViewModel
                                                        andToken:token];

--- a/Source/Modules/AddCard/Presenter/JPAddCardPresenter.m
+++ b/Source/Modules/AddCard/Presenter/JPAddCardPresenter.m
@@ -26,6 +26,7 @@
 #import "JPAddCardInteractor.h"
 #import "JPAddCardRouter.h"
 #import "JPAddCardViewController.h"
+#import "NSError+Judo.h"
 
 #import "JPAddress.h"
 #import "JPCard.h"
@@ -115,6 +116,11 @@
                }
 
                NSString *token = response.items.firstObject.cardDetails.cardToken;
+
+               if (!token) {
+                   [weakSelf.view updateViewWithError:NSError.judoTokenMissingError];
+                   return;
+               }
 
                [weakSelf.interactor updateKeychainWithCardModel:weakSelf.addCardViewModel
                                                        andToken:token];

--- a/Source/Modules/AddCard/View/JPAddCardView.m
+++ b/Source/Modules/AddCard/View/JPAddCardView.m
@@ -278,7 +278,7 @@
         _addCardButton.translatesAutoresizingMaskIntoConstraints = NO;
         _addCardButton.titleLabel.font = UIFont.headline;
         _addCardButton.layer.cornerRadius = 4.0f;
-        _addCardButton.backgroundColor = UIColor.jpTextColor;
+        _addCardButton.backgroundColor = UIColor.jpBlackColor;
     }
     return _addCardButton;
 }
@@ -300,7 +300,7 @@
     label.text = @"secure_server_transmission".localized;
     label.numberOfLines = 0;
     label.font = UIFont.caption;
-    label.textColor = UIColor.jpSubtitleColor;
+    label.textColor = UIColor.jpDarkGrayColor;
     return label;
 }
 

--- a/Source/Modules/AddCard/View/Subviews/JPCardInputField.m
+++ b/Source/Modules/AddCard/View/Subviews/JPCardInputField.m
@@ -38,7 +38,7 @@
     UIFont *placeholderFont = (viewModel.errorText) ? UIFont.body : UIFont.headlineLight;
 
     [self placeholderWithText:viewModel.placeholder
-                        color:UIColor.jpSubtitleColor
+                        color:UIColor.jpDarkGrayColor
                       andFont:placeholderFont];
 
     if (viewModel.errorText) {

--- a/Source/Modules/AddCard/View/Subviews/JPCardNumberField.m
+++ b/Source/Modules/AddCard/View/Subviews/JPCardNumberField.m
@@ -69,7 +69,7 @@
     [self setCardNetwork:viewModel.cardNetwork];
 
     [self placeholderWithText:viewModel.placeholder
-                        color:UIColor.jpSubtitleColor
+                        color:UIColor.jpDarkGrayColor
                       andFont:placeholderFont];
 
     self.text = viewModel.text;

--- a/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.h
+++ b/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.h
@@ -31,7 +31,7 @@
 @protocol JPPaymentMethodsBuilder
 
 /**
- * A method that builds the configured JPPaymentMethodsViewController
+ * A method that builds the configured JPPaymentMethodsViewController for a Payment transaction
  *
  * @param judoId - the Judo ID of the merchant
  * @param session - the current JudoKit session needed for creating transactions
@@ -40,12 +40,30 @@
  * @param consumerReference - the consumer's reference string
  * @param completionHandler - a response/error completion handler returned to the merchant
  */
-- (JPPaymentMethodsViewController *)buildModuleWithJudoID:(NSString *)judoId
-                                                  session:(JudoKit *)session
-                                    transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
-                                                   amount:(JPAmount *)amount
-                                        consumerReference:(NSString *)consumerReference
-                                        completionHandler:(JudoCompletionBlock)completion;
+- (JPPaymentMethodsViewController *)buildPaymentModuleWithJudoID:(NSString *)judoId
+                                                         session:(JudoKit *)session
+                                           transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
+                                                          amount:(JPAmount *)amount
+                                               consumerReference:(NSString *)consumerReference
+                                               completionHandler:(JudoCompletionBlock)completion;
+
+/**
+ * A method that builds the configured JPPaymentMethodsViewController for a PreAuth transaction
+ *
+ * @param judoId - the Judo ID of the merchant
+ * @param session - the current JudoKit session needed for creating transactions
+ * @param transitioningDelegate - a transitioning delegate needed for the custom Add Card transition animation
+ * @param amount - the amount of the transaction
+ * @param consumerReference - the consumer's reference string
+ * @param completionHandler - a response/error completion handler returned to the merchant
+ */
+- (JPPaymentMethodsViewController *)buildPreAuthModuleWithJudoID:(NSString *)judoId
+                                                         session:(JudoKit *)session
+                                           transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
+                                                          amount:(JPAmount *)amount
+                                               consumerReference:(NSString *)consumerReference
+                                               completionHandler:(JudoCompletionBlock)completion;
+
 @end
 
 @interface JPPaymentMethodsBuilderImpl : NSObject <JPPaymentMethodsBuilder>

--- a/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.h
+++ b/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.h
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 
 #import "JPSession.h"
+#import "JPReference.h"
 #import <Foundation/Foundation.h>
 
 @class JPPaymentMethodsViewController;
@@ -37,14 +38,14 @@
  * @param session - the current JudoKit session needed for creating transactions
  * @param transitioningDelegate - a transitioning delegate needed for the custom Add Card transition animation
  * @param amount - the amount of the transaction
- * @param consumerReference - the consumer's reference string
+ * @param reference - the reference for this transaction
  * @param completionHandler - a response/error completion handler returned to the merchant
  */
 - (JPPaymentMethodsViewController *)buildPaymentModuleWithJudoID:(NSString *)judoId
                                                          session:(JudoKit *)session
                                            transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
                                                           amount:(JPAmount *)amount
-                                               consumerReference:(NSString *)consumerReference
+                                                       reference:(JPReference *)reference
                                                completionHandler:(JudoCompletionBlock)completion;
 
 /**
@@ -54,14 +55,14 @@
  * @param session - the current JudoKit session needed for creating transactions
  * @param transitioningDelegate - a transitioning delegate needed for the custom Add Card transition animation
  * @param amount - the amount of the transaction
- * @param consumerReference - the consumer's reference string
+ * @param reference - the reference for this transaction
  * @param completionHandler - a response/error completion handler returned to the merchant
  */
 - (JPPaymentMethodsViewController *)buildPreAuthModuleWithJudoID:(NSString *)judoId
                                                          session:(JudoKit *)session
                                            transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
                                                           amount:(JPAmount *)amount
-                                               consumerReference:(NSString *)consumerReference
+                                                       reference:(JPReference *)reference
                                                completionHandler:(JudoCompletionBlock)completion;
 
 @end

--- a/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.h
+++ b/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.h
@@ -22,8 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-#import "JPSession.h"
 #import "JPReference.h"
+#import "JPSession.h"
 #import <Foundation/Foundation.h>
 
 @class JPPaymentMethodsViewController;

--- a/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.m
+++ b/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.m
@@ -36,11 +36,42 @@
 
 @implementation JPPaymentMethodsBuilderImpl
 
+- (JPPaymentMethodsViewController *)buildPaymentModuleWithJudoID:(NSString *)judoId
+                                                         session:(JudoKit *)session
+                                           transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
+                                                          amount:(JPAmount *)amount
+                                               consumerReference:(NSString *)consumerReference
+                                               completionHandler:(JudoCompletionBlock)completion {
+    return [self buildModuleWithJudoID:judoId
+                               session:session
+                 transitioningDelegate:transitioningDelegate
+                                amount:amount
+                     consumerReference:consumerReference
+                       transactionType:TransactionTypePayment
+                     completionHandler:completion];
+}
+
+- (JPPaymentMethodsViewController *)buildPreAuthModuleWithJudoID:(NSString *)judoId
+                                                         session:(JudoKit *)session
+                                           transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
+                                                          amount:(JPAmount *)amount
+                                               consumerReference:(NSString *)consumerReference
+                                               completionHandler:(JudoCompletionBlock)completion {
+    return [self buildModuleWithJudoID:judoId
+                               session:session
+                 transitioningDelegate:transitioningDelegate
+                                amount:amount
+                     consumerReference:consumerReference
+                       transactionType:TransactionTypePreAuth
+                     completionHandler:completion];
+}
+
 - (JPPaymentMethodsViewController *)buildModuleWithJudoID:(NSString *)judoId
                                                   session:(JudoKit *)session
                                     transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
                                                    amount:(JPAmount *)amount
                                         consumerReference:(NSString *)consumerReference
+                                          transactionType:(TransactionType)transactionType
                                         completionHandler:(JudoCompletionBlock)completion {
 
     JPPaymentMethodsViewController *viewController = [JPPaymentMethodsViewController new];
@@ -59,13 +90,13 @@
                                                                theme:session.theme
                                                           completion:completion];
 
-    JPTransaction *paymentTransaction = [session transactionForType:TransactionTypePayment
-                                                             judoId:judoId
-                                                             amount:amount
-                                                          reference:reference];
+    JPTransaction *transaction = [session transactionForType:transactionType
+                                                      judoId:judoId
+                                                      amount:amount
+                                                   reference:reference];
 
     JPPaymentMethodsInteractorImpl *interactor;
-    interactor = [[JPPaymentMethodsInteractorImpl alloc] initWithTransaction:paymentTransaction
+    interactor = [[JPPaymentMethodsInteractorImpl alloc] initWithTransaction:transaction
                                                            consumerReference:consumerReference
                                                                        theme:session.theme
                                                                    andAmount:amount];

--- a/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.m
+++ b/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.m
@@ -40,13 +40,13 @@
                                                          session:(JudoKit *)session
                                            transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
                                                           amount:(JPAmount *)amount
-                                               consumerReference:(NSString *)consumerReference
+                                                       reference:(JPReference *)reference
                                                completionHandler:(JudoCompletionBlock)completion {
     return [self buildModuleWithJudoID:judoId
                                session:session
                  transitioningDelegate:transitioningDelegate
                                 amount:amount
-                     consumerReference:consumerReference
+                             reference:reference
                        transactionType:TransactionTypePayment
                      completionHandler:completion];
 }
@@ -55,13 +55,13 @@
                                                          session:(JudoKit *)session
                                            transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
                                                           amount:(JPAmount *)amount
-                                               consumerReference:(NSString *)consumerReference
+                                                       reference:(JPReference *)reference
                                                completionHandler:(JudoCompletionBlock)completion {
     return [self buildModuleWithJudoID:judoId
                                session:session
                  transitioningDelegate:transitioningDelegate
                                 amount:amount
-                     consumerReference:consumerReference
+                             reference:reference
                        transactionType:TransactionTypePreAuth
                      completionHandler:completion];
 }
@@ -70,14 +70,12 @@
                                                   session:(JudoKit *)session
                                     transitioningDelegate:(SliderTransitioningDelegate *)transitioningDelegate
                                                    amount:(JPAmount *)amount
-                                        consumerReference:(NSString *)consumerReference
+                                                reference:(JPReference *)reference
                                           transactionType:(TransactionType)transactionType
                                         completionHandler:(JudoCompletionBlock)completion {
 
     JPPaymentMethodsViewController *viewController = [JPPaymentMethodsViewController new];
     JPPaymentMethodsPresenterImpl *presenter = [JPPaymentMethodsPresenterImpl new];
-
-    JPReference *reference = [JPReference consumerReference:consumerReference];
 
     JPTransaction *addCardTransaction = [session transactionForType:TransactionTypeSaveCard
                                                              judoId:judoId
@@ -97,7 +95,7 @@
 
     JPPaymentMethodsInteractorImpl *interactor;
     interactor = [[JPPaymentMethodsInteractorImpl alloc] initWithTransaction:transaction
-                                                           consumerReference:consumerReference
+                                                                   reference:reference
                                                                        theme:session.theme
                                                                    andAmount:amount];
 

--- a/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.h
+++ b/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.h
@@ -22,8 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-#import "JPSession.h"
 #import "JPReference.h"
+#import "JPSession.h"
 #import <Foundation/Foundation.h>
 
 @class JPStoredCardDetails, JPTheme, JPAmount, JPTransaction;

--- a/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.h
+++ b/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.h
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 
 #import "JPSession.h"
+#import "JPReference.h"
 #import <Foundation/Foundation.h>
 
 @class JPStoredCardDetails, JPTheme, JPAmount, JPTransaction;
@@ -65,14 +66,14 @@
  * A designated initializer that sets up the JPTheme object needed for view customization
  *
  * @param transaction - an instance describing the JPTransaction details
- * @param consumerReference - the consumer reference needed for the transaction
+ * @param reference - the reference needed for the transaction
  * @param theme - an instance of JPTheme that is used to configure the payment methods flow
  * @param amount - the amount of the transaction
  *
  * @returns a configured instance of JPPaymentMethodsInteractor
  */
 - (instancetype)initWithTransaction:(JPTransaction *)transaction
-                  consumerReference:(NSString *)consumerReference
+                          reference:(JPReference *)reference
                               theme:(JPTheme *)theme
                           andAmount:(JPAmount *)amount;
 

--- a/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.m
+++ b/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.m
@@ -31,7 +31,7 @@
 
 @interface JPPaymentMethodsInteractorImpl ()
 @property (nonatomic, strong) JPTransaction *transaction;
-@property (nonatomic, strong) NSString *consumerReference;
+@property (nonatomic, strong) JPReference *reference;
 @property (nonatomic, strong) JPTheme *theme;
 @property (nonatomic, strong) JPAmount *amount;
 @end
@@ -39,12 +39,12 @@
 @implementation JPPaymentMethodsInteractorImpl
 
 - (instancetype)initWithTransaction:(JPTransaction *)transaction
-                  consumerReference:(NSString *)consumerReference
+                          reference:(JPReference *)reference
                               theme:(JPTheme *)theme
                           andAmount:(JPAmount *)amount {
     if (self = [super init]) {
         self.transaction = transaction;
-        self.consumerReference = consumerReference;
+        self.reference = reference;
         self.theme = theme;
         self.amount = amount;
     }
@@ -83,7 +83,7 @@
 - (void)paymentTransactionWithToken:(NSString *)token
                       andCompletion:(JudoCompletionBlock)completion {
 
-    JPPaymentToken *paymentToken = [[JPPaymentToken alloc] initWithConsumerToken:self.consumerReference
+    JPPaymentToken *paymentToken = [[JPPaymentToken alloc] initWithConsumerToken:self.reference.consumerReference
                                                                        cardToken:token];
 
     [self.transaction setPaymentToken:paymentToken];

--- a/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
+++ b/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
@@ -95,7 +95,7 @@
 
 - (void)handlePaymentError:(NSError *)error {
     [self.router completeTransactionWithResponse:nil andError:error];
-    [self.view displayAlertWithError:error];
+    [self.view displayAlertWithTitle:@"card_transaction_unsuccesful_error".localized andError:error];
 }
 
 #pragma mark - Helper methods

--- a/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.h
+++ b/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.h
@@ -40,11 +40,12 @@
 - (void)configureWithViewModel:(JPPaymentMethodsViewModel *)viewModel;
 
 /**
- * A method that displays a UIAlertController based on a specified NSError
+ * Convenience method for displaying alert controllers based on a specified error with an optional title
  *
- * @param error - an instance of NSError describing the error
+ * @param title - an optional NSString that defines the title of the alert
+ * @param error - an NSError instance describing the current error
  */
-- (void)displayAlertWithError:(NSError *)error;
+- (void)displayAlertWithTitle:(NSString *)title andError:(NSError *)error;
 
 @end
 

--- a/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
+++ b/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
@@ -113,7 +113,8 @@
 - (void)displayAlertWithError:(NSError *)error {
     [self.paymentMethodsView.headerView.payButton stopLoading];
     self.paymentMethodsView.userInteractionEnabled = YES;
-    [super displayAlertWithError:error andTitle:@"card_transaction_unsuccesful_error".localized];
+    [self triggerNotificationFeedbackWithType:UINotificationFeedbackTypeError];
+    [super displayAlertWithTitle:@"card_transaction_unsuccesful_error".localized andError:error];
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
+++ b/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
@@ -31,6 +31,7 @@
 #import "JPPaymentMethodsSelectionCell.h"
 #import "JPPaymentMethodsView.h"
 #import "JPPaymentMethodsViewModel.h"
+#import "NSString+Additions.h"
 #import "UIColor+Judo.h"
 #import "UIImage+Icons.h"
 #import "UIViewController+Additions.h"
@@ -112,7 +113,7 @@
 - (void)displayAlertWithError:(NSError *)error {
     [self.paymentMethodsView.headerView.payButton stopLoading];
     self.paymentMethodsView.userInteractionEnabled = YES;
-    [super displayAlertWithError:error];
+    [super displayAlertWithError:error andTitle:@"card_transaction_unsuccesful_error".localized];
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
+++ b/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
@@ -110,11 +110,11 @@
     [self.paymentMethodsView.tableView reloadData];
 }
 
-- (void)displayAlertWithError:(NSError *)error {
+- (void)displayAlertWithTitle:(NSString *)title andError:(NSError *)error {
     [self.paymentMethodsView.headerView.payButton stopLoading];
     self.paymentMethodsView.userInteractionEnabled = YES;
     [self triggerNotificationFeedbackWithType:UINotificationFeedbackTypeError];
-    [super displayAlertWithTitle:@"card_transaction_unsuccesful_error".localized andError:error];
+    [super displayAlertWithTitle:title andError:error];
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/Source/Modules/PaymentMethods/View/Subviews/Cells/CardCell/JPPaymentMethodsCardCell.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/Cells/CardCell/JPPaymentMethodsCardCell.m
@@ -143,7 +143,7 @@
         _titleLabel = [UILabel new];
         _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _titleLabel.font = UIFont.bodyBold;
-        _titleLabel.textColor = UIColor.jpTextColor;
+        _titleLabel.textColor = UIColor.jpBlackColor;
     }
     return _titleLabel;
 }
@@ -153,7 +153,7 @@
         _subtitleLabel = [UILabel new];
         _subtitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _subtitleLabel.font = UIFont.caption;
-        _subtitleLabel.textColor = UIColor.jpSubtitleColor;
+        _subtitleLabel.textColor = UIColor.jpDarkGrayColor;
     }
     return _subtitleLabel;
 }

--- a/Source/Modules/PaymentMethods/View/Subviews/Cells/CardListFooterCell/JPPaymentMethodsCardListFooterCell.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/Cells/CardListFooterCell/JPPaymentMethodsCardListFooterCell.m
@@ -110,7 +110,7 @@
     if (!_addCardButton) {
         _addCardButton = [UIButton new];
         _addCardButton.translatesAutoresizingMaskIntoConstraints = NO;
-        [_addCardButton setTitleColor:UIColor.jpTextColor forState:UIControlStateNormal];
+        [_addCardButton setTitleColor:UIColor.jpBlackColor forState:UIControlStateNormal];
         _addCardButton.titleLabel.font = UIFont.bodyBold;
 
         [self.addCardButton addTarget:self

--- a/Source/Modules/PaymentMethods/View/Subviews/Cells/CardListHeaderCell/JPPaymentMethodsCardListHeaderCell.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/Cells/CardListHeaderCell/JPPaymentMethodsCardListHeaderCell.m
@@ -96,7 +96,7 @@
     if (!_titleLabel) {
         _titleLabel = [UILabel new];
         _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
-        _titleLabel.textColor = UIColor.jpTextColor;
+        _titleLabel.textColor = UIColor.jpBlackColor;
         _titleLabel.font = UIFont.headline;
     }
     return _titleLabel;
@@ -107,7 +107,7 @@
         _actionButton = [UIButton new];
         _actionButton.translatesAutoresizingMaskIntoConstraints = NO;
         _actionButton.titleLabel.font = UIFont.bodyBold;
-        [_actionButton setTitleColor:UIColor.jpTextColor forState:UIControlStateNormal];
+        [_actionButton setTitleColor:UIColor.jpBlackColor forState:UIControlStateNormal];
     }
     return _actionButton;
 }

--- a/Source/Modules/PaymentMethods/View/Subviews/Header/JPPaymentMethodsEmptyHeaderView.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/Header/JPPaymentMethodsEmptyHeaderView.m
@@ -81,7 +81,7 @@
     if (!_titleLabel) {
         _titleLabel = [UILabel new];
         _titleLabel.font = UIFont.title;
-        _titleLabel.textColor = UIColor.jpTextColor;
+        _titleLabel.textColor = UIColor.jpBlackColor;
         _titleLabel.text = @"choose_payment_method".localized;
         _titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
     }
@@ -93,7 +93,7 @@
         _textLabel = [UILabel new];
         _textLabel.numberOfLines = 0;
         _textLabel.font = UIFont.body;
-        _textLabel.textColor = UIColor.jpTextColor;
+        _textLabel.textColor = UIColor.jpBlackColor;
         _textLabel.text = @"no_cards_added".localized;
         _textLabel.translatesAutoresizingMaskIntoConstraints = NO;
     }

--- a/Source/Modules/PaymentMethods/View/Subviews/JPPaymentMethodsHeaderView.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/JPPaymentMethodsHeaderView.m
@@ -197,7 +197,7 @@
         _amountValueLabel = [UILabel new];
         _amountValueLabel.numberOfLines = 0;
         _amountValueLabel.font = UIFont.largeTitle;
-        _amountValueLabel.textColor = UIColor.jpTextColor;
+        _amountValueLabel.textColor = UIColor.jpBlackColor;
         _amountValueLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _amountValueLabel.textAlignment = NSTextAlignmentCenter;
     }
@@ -210,7 +210,7 @@
         _amountPrefixLabel.numberOfLines = 0;
         _amountPrefixLabel.text = @"you_will_pay".localized;
         _amountPrefixLabel.font = UIFont.body;
-        _amountPrefixLabel.textColor = UIColor.jpTextColor;
+        _amountPrefixLabel.textColor = UIColor.jpBlackColor;
         _amountPrefixLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _amountPrefixLabel.textAlignment = NSTextAlignmentCenter;
     }
@@ -223,7 +223,7 @@
         _payButton.translatesAutoresizingMaskIntoConstraints = NO;
         _payButton.layer.cornerRadius = 4.0f;
         _payButton.titleLabel.font = UIFont.headline;
-        [_payButton setBackgroundImage:UIColor.jpTextColor.asImage forState:UIControlStateNormal];
+        [_payButton setBackgroundImage:UIColor.jpBlackColor.asImage forState:UIControlStateNormal];
         [_payButton setClipsToBounds:YES];
     }
     return _payButton;

--- a/Source/View/JPTextField.m
+++ b/Source/View/JPTextField.m
@@ -81,9 +81,9 @@
 #pragma mark - User Actions
 
 - (void)displayErrorWithText:(NSString *)text {
-    self.floatingTextField.textColor = UIColor.jpErrorColor;
+    self.floatingTextField.textColor = UIColor.jpRedColor;
     [self.floatingTextField displayFloatingLabelWithText:text
-                                                   color:UIColor.jpErrorColor];
+                                                   color:UIColor.jpRedColor];
 }
 
 - (void)clearError {
@@ -104,7 +104,7 @@
 - (void)setupViews {
 
     self.layer.cornerRadius = 6.0f;
-    self.backgroundColor = UIColor.jpTextFieldBackgroundColor;
+    self.backgroundColor = UIColor.jpLightGrayColor;
     self.translatesAutoresizingMaskIntoConstraints = NO;
 
     [self addSubview:self.stackView];
@@ -121,9 +121,9 @@
         _floatingTextField = [JPFloatingTextField new];
         _floatingTextField.translatesAutoresizingMaskIntoConstraints = NO;
         _floatingTextField.font = UIFont.headlineLight;
-        _floatingTextField.textColor = UIColor.jpTextColor;
+        _floatingTextField.textColor = UIColor.jpBlackColor;
         [_floatingTextField placeholderWithText:@""
-                                          color:UIColor.jpPlaceholderColor
+                                          color:UIColor.jpGrayColor
                                         andFont:UIFont.headlineLight];
 
         [_floatingTextField addTarget:self


### PR DESCRIPTION
- Added new method to JudoKit to invoke a `PreAuth` transaction with the built-in payment method screen;
- Added the new option to the Obj-C demo app;
- Renamed the methods from `invokePayment` to `invokePaymentMethods` to distinguish them from the normal payment screens;