### PR TITLE
Changed the iDEAL redirect callback logic

### DIFF
--- a/JudoKitObjCExampleApp/Controllers/MainViewController.m
+++ b/JudoKitObjCExampleApp/Controllers/MainViewController.m
@@ -197,7 +197,6 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
                         paymentMethods:PaymentMethodsAll
                applePayConfiguratation:configuration
                            cardDetails:nil
-                    redirectCompletion:nil
                             completion:^(JPResponse * response, NSError * error) {
                                 if (error || response.items.count == 0) {
                                     if (error.domain == JudoErrorDomain && error.code == JudoErrorUserDidCancel) {
@@ -406,7 +405,6 @@ static NSString * const kCellIdentifier = @"com.judo.judopaysample.tableviewcell
     [self.judoKitSession invokeIDEALPaymentWithJudoId:judoId
                                                amount:[JPAmount amount:@"0.01" currency:@"EUR"]
                                             reference:[JPReference consumerReference:self.reference]
-                                   redirectCompletion:nil
                                            completion:^(JPResponse *response, NSError *error) {
 
         if (error || response.items.count == 0) {

--- a/Source/Controller/JudoPaymentMethodsViewController.h
+++ b/Source/Controller/JudoPaymentMethodsViewController.h
@@ -35,7 +35,6 @@
  *  @param theme            The current theme
  *  @param viewModel        The view configuration model
  *  @param session          The current judo apiSession
- *  @param redirectCompletion         An optional completion handler that. if set, returns the redirect response/error
  *  @param completion       Completion block called when transaction has been finished
  *
  *  @return a JudoPaymentMethodsViewController instance
@@ -43,6 +42,5 @@
 - (instancetype _Nonnull)initWithTheme:(nonnull JPTheme *)theme
                              viewModel:(nonnull JudoPaymentMethodsViewModel *)viewModel
                         currentSession:(nonnull JudoKit *)session
-                    redirectCompletion:(nullable IDEALRedirectCompletion)redirectCompletion
                          andCompletion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
 @end

--- a/Source/Controller/JudoPaymentMethodsViewController.m
+++ b/Source/Controller/JudoPaymentMethodsViewController.m
@@ -48,7 +48,6 @@
 @property (nonatomic, strong) JudoPaymentMethodsViewModel *viewModel;
 
 @property (nonatomic, strong) JudoCompletionBlock completionBlock;
-@property (nonatomic, strong) IDEALRedirectCompletion redirectCompletionBlock;
 @property (nonatomic, strong) JudoKit *judoKitSession;
 
 @property PaymentMethods methods;
@@ -60,14 +59,12 @@
 - (instancetype)initWithTheme:(JPTheme *)theme
                     viewModel:(JudoPaymentMethodsViewModel *)viewModel
                currentSession:(JudoKit *)session
-           redirectCompletion:(IDEALRedirectCompletion)redirectCompletion
                 andCompletion:(JudoCompletionBlock)completion {
     if (self = [super init]) {
         _theme = theme;
         _viewModel = viewModel;
         _judoKitSession = session;
         _completionBlock = completion;
-        _redirectCompletionBlock = redirectCompletion;
     }
     return self;
 }
@@ -248,7 +245,6 @@
     [self.judoKitSession invokeIDEALPaymentWithJudoId:self.viewModel.judoId
                                                amount:self.viewModel.amount
                                             reference:self.viewModel.reference
-                                   redirectCompletion:self.redirectCompletionBlock
                                            completion:^(JPResponse *response, NSError *error) {
                                                if (error && error.domain == JudoErrorDomain && error.code == JudoErrorUserDidCancel) {
                                                    [weakSelf dismissViewControllerAnimated:YES completion:nil];

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -260,7 +260,6 @@ static NSString *__nonnull const JudoKitVersion = @"9.0.0";
  *  @param reference            The consumer reference for this transaction
  *  @param methods              The payment methods to be shown
  *  @param cardDetails          The card details to present in the input fields
- *  @param redirectCompletion             An optional completion handler that, once implemented, will allow you to capture the IDEAL redirect response data
  *  @param completion           The completion handler which will respond with a JPResponse object or an NSError
  */
 - (void)invokePayment:(nonnull NSString *)judoId
@@ -269,7 +268,6 @@ static NSString *__nonnull const JudoKitVersion = @"9.0.0";
              paymentMethods:(PaymentMethods)methods
     applePayConfiguratation:(nullable ApplePayConfiguration *)applePayConfigs
                 cardDetails:(nullable JPCardDetails *)cardDetails
-         redirectCompletion:(nullable IDEALRedirectCompletion)redirectCompletion
                  completion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
 
 /**
@@ -473,13 +471,11 @@ static NSString *__nonnull const JudoKitVersion = @"9.0.0";
  *  @param judoId           The judoID of the merchant to receive the token pre-auth
  *  @param amount           The amount and currency of the iDEAL transaction (currency is limited to EUR)
  *  @param reference     Holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information up to 1024 characters
- *  @param redirectCompletion        A completion block that can be optionally set to return back the redirect response for iDEAL transactions
  *  @param completion   The completion handler which will respond with a JPResponse object or an NSError
  */
 - (void)invokeIDEALPaymentWithJudoId:(nonnull NSString *)judoId
                               amount:(nonnull JPAmount *)amount
                            reference:(nonnull JPReference *)reference
-                  redirectCompletion:(nullable IDEALRedirectCompletion)redirectCompletion
                           completion:(nonnull JudoCompletionBlock)completion;
 
 @end

--- a/Source/JudoKit.m
+++ b/Source/JudoKit.m
@@ -332,7 +332,6 @@
              paymentMethods:(PaymentMethods)methods
     applePayConfiguratation:(nullable ApplePayConfiguration *)applePayConfigs
                 cardDetails:(nullable JPCardDetails *)cardDetails
-         redirectCompletion:(nullable IDEALRedirectCompletion)redirectCompletion
                  completion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion {
 
     JudoPaymentMethodsViewModel *viewModel = [[JudoPaymentMethodsViewModel alloc] initWithJudoId:judoId
@@ -346,7 +345,6 @@
     JudoPaymentMethodsViewController *viewController = [[JudoPaymentMethodsViewController alloc] initWithTheme:self.theme
                                                                                                      viewModel:viewModel
                                                                                                 currentSession:self
-                                                                                            redirectCompletion:redirectCompletion
                                                                                                  andCompletion:completion];
     viewController.modalPresentationStyle = UIModalPresentationFormSheet;
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
@@ -551,7 +549,6 @@
 - (void)invokeIDEALPaymentWithJudoId:(NSString *)judoId
                               amount:(JPAmount *)amount
                            reference:(JPReference *)reference
-                  redirectCompletion:(IDEALRedirectCompletion)redirectCompletion
                           completion:(JudoCompletionBlock)completion {
 
     IDEALFormViewController *controller = [[IDEALFormViewController alloc] initWithJudoId:judoId
@@ -560,7 +557,6 @@
                                                                                 reference:reference
                                                                                   session:self.apiSession
                                                                           paymentMetadata:self.paymentMetadata
-                                                                       redirectCompletion:redirectCompletion
                                                                                completion:completion];
 
     controller.modalPresentationStyle = UIModalPresentationFormSheet;

--- a/Source/Managers/IDEALService.h
+++ b/Source/Managers/IDEALService.h
@@ -38,9 +38,6 @@ typedef NS_ENUM(NSUInteger, IDEALStatus) {
 
 @interface IDEALService : NSObject
 
-typedef void (^IDEALRedirectCompletion)(JPResponse *_Nullable);
-typedef void (^JudoRedirectCompletion)(NSString *_Nullable, NSString *_Nullable, NSError *_Nullable);
-
 /**
  * A string describing the account holder name
  */
@@ -54,14 +51,12 @@ typedef void (^JudoRedirectCompletion)(NSString *_Nullable, NSString *_Nullable,
  * @param reference    Holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information up to 1024 characters
  * @param session         An instance of JPSession that is used to make API requests
  * @param paymentMetadata                       Freeformat optional JSON metadata
- * @param redirectCompletion        A completion block that can be optionally set to return back the redirect response for iDEAL transactions
  */
 - (nonnull instancetype)initWithJudoId:(nonnull NSString *)judoId
                                 amount:(nonnull JPAmount *)amount
                              reference:(nonnull JPReference *)reference
                                session:(nonnull JPSession *)session
-                       paymentMetadata:(nullable NSDictionary *)paymentMetadata
-                    redirectCompletion:(nullable IDEALRedirectCompletion)redirectCompletion;
+                       paymentMetadata:(nullable NSDictionary *)paymentMetadata;
 
 /**
  * Method used for returning a redirect URL based on the specified iDEAL bank
@@ -70,7 +65,7 @@ typedef void (^JudoRedirectCompletion)(NSString *_Nullable, NSString *_Nullable,
  * @param completion  A completion block that either returns the redirect URL string or returns an error
  */
 - (void)redirectURLForIDEALBank:(nonnull IDEALBank *)iDealBank
-                     completion:(nonnull JudoRedirectCompletion)completion;
+                     completion:(nonnull JudoCompletionBlock)completion;
 
 /**
  * Method used for returning a redirect URL based on the specified iDEAL bank

--- a/Source/Managers/IDEALService.m
+++ b/Source/Managers/IDEALService.m
@@ -28,7 +28,6 @@
 #import "JPOrderDetails.h"
 #import "JPReference.h"
 #import "JPResponse.h"
-#import "JPSession.h"
 #import "JPTransactionData.h"
 #import "NSError+Judo.h"
 
@@ -41,7 +40,6 @@
 @property (nonatomic, strong) JPSession *session;
 @property (nonatomic, strong) NSTimer *timer;
 @property (nonatomic, assign) BOOL didTimeout;
-@property (nonatomic, strong) IDEALRedirectCompletion redirectCompletion;
 
 @end
 
@@ -54,8 +52,7 @@ static NSString *statusEndpoint = @"order/bank/statusrequest/";
                         amount:(JPAmount *)amount
                      reference:(JPReference *)reference
                        session:(JPSession *)session
-               paymentMetadata:(NSDictionary *)paymentMetadata
-            redirectCompletion:(IDEALRedirectCompletion)redirectCompletion {
+               paymentMetadata:(NSDictionary *)paymentMetadata {
 
     if (self = [super init]) {
         self.judoId = judoId;
@@ -64,14 +61,13 @@ static NSString *statusEndpoint = @"order/bank/statusrequest/";
         self.session = session;
         self.paymentMetadata = paymentMetadata;
         self.didTimeout = false;
-        self.redirectCompletion = redirectCompletion;
     }
 
     return self;
 }
 
 - (void)redirectURLForIDEALBank:(IDEALBank *)iDealBank
-                     completion:(JudoRedirectCompletion)completion {
+                     completion:(JudoCompletionBlock)completion {
 
     NSString *fullURL = [NSString stringWithFormat:@"%@%@", self.session.iDealEndpoint, redirectEndpoint];
 
@@ -81,16 +77,11 @@ static NSString *statusEndpoint = @"order/bank/statusrequest/";
                 JPTransactionData *data = response.items.firstObject;
 
                 if (data.orderDetails.orderId && data.redirectUrl) {
-
-                    if (self.redirectCompletion) {
-                        self.redirectCompletion(response);
-                    }
-
-                    completion(data.redirectUrl, data.orderDetails.orderId, error);
+                    completion(response, error);
                     return;
                 }
 
-                completion(nil, nil, NSError.judoResponseParseError);
+                completion(nil, NSError.judoResponseParseError);
             }];
 }
 

--- a/Source/iDEAL/IDEALFormViewController.h
+++ b/Source/iDEAL/IDEALFormViewController.h
@@ -45,7 +45,6 @@
  *  @param reference                     Holds consumer and payment reference and a meta data dictionary which can hold any kind of JSON formatted information up to 1024 characters
  *  @param session                          An instance of a JPSession object that is used for making API requests
  *  @param paymentMetadata        An optional parameter for additional metadata
- *  @param redirectCompletion        A completion block that can be optionally set to return back the redirect response for iDEAL transactions
  *  @param completion                   Completion block called when transaction has been finished
  *
  *  @return an initialized IDEALFormViewController object
@@ -56,7 +55,6 @@
                              reference:(nonnull JPReference *)reference
                                session:(nonnull JPSession *)session
                        paymentMetadata:(nullable NSDictionary *)paymentMetadata
-                    redirectCompletion:(nullable IDEALRedirectCompletion)redirectCompletion
                             completion:(nonnull JudoCompletionBlock)completion;
 
 @end

--- a/Source/iDEAL/IDEALFormViewController.m
+++ b/Source/iDEAL/IDEALFormViewController.m
@@ -239,6 +239,7 @@
 
                                                 [self.transactionStatusView changeStatusTo:orderStatus
                                                                                andSubtitle:nil];
+                                                self.completionBlock(response, error);
                                             }];
 }
 

--- a/Source/iDEAL/IDEALFormViewController.m
+++ b/Source/iDEAL/IDEALFormViewController.m
@@ -64,6 +64,7 @@
 @property (nonatomic, strong) NSString *checksum;
 @property (nonatomic, strong) NSString *redirectUrl;
 @property (nonatomic, assign) BOOL shouldDismissWebView;
+@property (nonatomic, strong) JPResponse *redirectResponse;
 
 @property (nonatomic, strong) NSTimer *delayTimer;
 @property (nonatomic, strong) IDEALService *idealService;
@@ -84,7 +85,6 @@
                      reference:(JPReference *)reference
                        session:(JPSession *)session
                paymentMetadata:(NSDictionary *)paymentMetadata
-            redirectCompletion:(IDEALRedirectCompletion)redirectCompletion
                     completion:(JudoCompletionBlock)completion {
 
     if (self = [super init]) {
@@ -94,8 +94,7 @@
                                                           amount:amount
                                                        reference:reference
                                                          session:session
-                                                 paymentMetadata:paymentMetadata
-                                              redirectCompletion:redirectCompletion];
+                                                 paymentMetadata:paymentMetadata];
     }
 
     return self;
@@ -144,17 +143,19 @@
     [self.view endEditing:YES];
     self.idealService.accountHolderName = self.nameInputField.textField.text;
     [self.idealService redirectURLForIDEALBank:self.selectedBank
-                                    completion:^(NSString *redirectUrl, NSString *orderId, NSError *error) {
+                                    completion:^(JPResponse *response, NSError *error) {
                                         if (error) {
                                             self.completionBlock(nil, error);
                                             return;
                                         }
 
-                                        self.orderId = orderId;
-                                        self.redirectUrl = redirectUrl;
+                                        JPTransactionData *transactionData = response.items.firstObject;
+                                        self.redirectUrl = transactionData.redirectUrl;
+                                        self.orderId = transactionData.orderDetails.orderId;
+                                        self.redirectResponse = response;
 
                                         self.navigationItem.rightBarButtonItem.enabled = NO;
-                                        [self loadWebViewWithURLString:redirectUrl];
+                                        [self loadWebViewWithURLString:self.redirectUrl];
                                     }];
 }
 
@@ -222,14 +223,14 @@
                                                 [self.delayTimer invalidate];
                                                 if (error && error.localizedDescription == NSError.judoRequestTimeoutError.localizedDescription) {
                                                     [self.transactionStatusView changeStatusTo:IDEALStatusTimeout andSubtitle:nil];
-                                                    self.completionBlock(nil, NSError.judoRequestTimeoutError);
+                                                    self.completionBlock(self.redirectResponse, NSError.judoRequestTimeoutError);
                                                     return;
                                                 }
 
                                                 if (error) {
                                                     [self.transactionStatusView changeStatusTo:IDEALStatusError
                                                                                    andSubtitle:error.localizedDescription];
-                                                    self.completionBlock(nil, error);
+                                                    self.completionBlock(self.redirectResponse, error);
                                                     return;
                                                 }
 


### PR DESCRIPTION
### Changed the iDEAL redirect callback logic to the following:
- **When** successful `/sale` and `/statusrequest` response
   **Then** return `/statusrequest` JPResponse

- **When** successful `/sale` and failed `/statusrequest` response
**Then** return `/sale` JPResponse and `/statusrequest` NSError

- **When** failed `/sale` response
**Then** return `/sale` NSError