### PR TITLE
[EP-713] Improve Transaction Request Delays

### DIFF
--- a/JudoKitObjC.xcodeproj/project.pbxproj
+++ b/JudoKitObjC.xcodeproj/project.pbxproj
@@ -1549,8 +1549,8 @@
 		3000732B23FA9C1C0099F3C5 /* TransactionEnricher */ = {
 			isa = PBXGroup;
 			children = (
-				3000732C23FA9C1C0099F3C5 /* JPTransactionEnricher.m */,
 				3000732D23FA9C1C0099F3C5 /* JPTransactionEnricher.h */,
+				3000732C23FA9C1C0099F3C5 /* JPTransactionEnricher.m */,
 			);
 			path = TransactionEnricher;
 			sourceTree = "<group>";

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -30,6 +30,7 @@
 #import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
 
+static NSString *__nonnull const JudoKitName = @"iOS-ObjC";
 static NSString *__nonnull const JudoKitVersion = @"8.2.1";
 
 @interface JudoKit : NSObject

--- a/Source/Models/TransactionEnricher/JPTransactionEnricher.m
+++ b/Source/Models/TransactionEnricher/JPTransactionEnricher.m
@@ -85,7 +85,8 @@
            withCompletion:(nonnull void (^)(void))completion {
 
     if (![self shouldEnrichTransaction:transaction]) {
-        return completion();
+        completion();
+        return;
     }
 
     self.completionBlock = completion;

--- a/Source/Models/TransactionEnricher/JPTransactionEnricher.m
+++ b/Source/Models/TransactionEnricher/JPTransactionEnricher.m
@@ -40,96 +40,160 @@
 @interface JPTransactionEnricher () <CLLocationManagerDelegate>
 
 @property (nonatomic, strong) DeviceDNA *deviceDNA;
+@property (nonatomic, weak) JPTransaction *transaction;
 @property (nonatomic, strong) CLLocationManager *locationManager;
 @property (nonatomic, strong) CLLocation *lastKnownLocation;
-@property (nonatomic, assign) BOOL didFindLocation;
-
-@property (nonatomic, copy, nullable) void (^completionBlock)(void);
-@property (nonatomic, weak) JPTransaction *transaction;
-
 @property (nonatomic, strong) NSArray *enricheablePaths;
+@property (nonatomic, copy, nullable) void (^completionBlock)(void);
+
 @end
 
 @implementation JPTransactionEnricher
 
-- (instancetype)initWithToken:(NSString *)token secret:(NSString *)secret {
-    if (self = [super init]) {
-        Credentials *credentials = [[Credentials alloc] initWithToken:token secret:secret];
-        _deviceDNA = [[DeviceDNA alloc] initWithCredentials:credentials];
-        [self setDidFindLocation:NO];
-        _locationManager = [CLLocationManager new];
-        _locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters;
-        _locationManager.delegate = self;
+#pragma mark - Initializers
 
-        _enricheablePaths = @[ @"transactions/payments",
-                               @"transactions/preauths",
-                               @"transactions/registercard",
-                               @"transactions/checkcard" ];
+- (instancetype)initWithToken:(NSString *)token
+                       secret:(NSString *)secret {
+
+    if (self = [super init]) {
+        [self requestLocation];
+        [self setupDeviceDNAWithToken:token
+                               secret:secret];
     }
     return self;
 }
 
+#pragma mark - Setup methods
+
+- (void)setupDeviceDNAWithToken:(NSString *)token
+                         secret:(NSString *)secret {
+    Credentials *credentials = [[Credentials alloc] initWithToken:token
+                                                           secret:secret];
+
+    self.deviceDNA = [[DeviceDNA alloc] initWithCredentials:credentials];
+}
+
+- (void)requestLocation {
+    if (self.shouldRequestLocation) {
+        [self.locationManager requestLocation];
+    }
+}
+
+#pragma mark - Public methods
+
 - (void)enrichTransaction:(nonnull JPTransaction *)transaction
            withCompletion:(nonnull void (^)(void))completion {
-    [self setDidFindLocation:NO];
-    if (![self.enricheablePaths containsObject:transaction.transactionPath]) {
-        completion();
-        return;
+
+    if (![self shouldEnrichTransaction:transaction]) {
+        return completion();
     }
 
     self.completionBlock = completion;
     self.transaction = transaction;
 
-    if (CLLocationManager.locationServicesEnabled && (CLLocationManager.authorizationStatus == kCLAuthorizationStatusAuthorizedAlways || CLLocationManager.authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse)) {
-        [self.locationManager requestLocation];
-    } else {
-        [self enrichWithLocation:self.lastKnownLocation];
-    }
+    [self enrichWithLocation:self.lastKnownLocation];
 }
 
+#pragma mark - Helper methods
+
 - (void)enrichWithLocation:(CLLocation *)location {
-    [self.deviceDNA getDeviceSignals:^(NSDictionary<NSString *, NSString *> *_Nullable device, NSError *_Nullable error) {
-        JPEnhancedPaymentDetail *detail = [self buildEnhancedPaymentDetail:device andLocation:location];
+
+    [self.deviceDNA getDeviceSignals:^(NSDictionary *device, NSError *error) {
+
+        JPEnhancedPaymentDetail *detail;
+        detail = [self buildEnhancedPaymentDetail:device
+                                      andLocation:location];
+
         [self.transaction setPaymentDetail:detail];
         [self.transaction setDeviceSignal:device];
         self.completionBlock();
     }];
 }
 
-- (JPEnhancedPaymentDetail *)buildEnhancedPaymentDetail:(NSDictionary<NSString *, NSString *> *)device
+- (JPEnhancedPaymentDetail *)buildEnhancedPaymentDetail:(NSDictionary *)device
                                             andLocation:(CLLocation *)location {
 
     JPThreeDSecure *threeDSecure = [JPThreeDSecure secureWithBrowser:[JPBrowser new]];
 
-    JPConsumerDevice *consumerDevice = [JPConsumerDevice deviceWithIpAddress:getIPAddress()
-                                                               clientDetails:[JPClientDetails detailsWithDictionary:device]
+    JPClientDetails *clientDetails = [JPClientDetails detailsWithDictionary:device];
+
+    JPConsumerDevice *consumerDevice;
+    consumerDevice = [JPConsumerDevice deviceWithIpAddress:getIPAddress()
+                                                               clientDetails:clientDetails
                                                                  geoLocation:location
                                                                 threeDSecure:threeDSecure];
 
-    return [JPEnhancedPaymentDetail detailWithSdkInfo:[JPSDKInfo infoWithVersion:JudoKitVersion name:@"iOS-ObjC"]
+    JPSDKInfo *sdkInfo = [JPSDKInfo infoWithVersion:JudoKitVersion
+                                               name:JudoKitName];
+
+    return [JPEnhancedPaymentDetail detailWithSdkInfo:sdkInfo
                                        consumerDevice:consumerDevice];
 }
 
-#pragma mark : CLLocationManagerDelegate
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
-    if (locations.count > 0) {
-        self.lastKnownLocation = locations.lastObject;
-    }
-    if (self.didFindLocation == NO) {
-        [self enrichWithLocation:self.lastKnownLocation];
-        [self setDidFindLocation:YES];
+#pragma mark - Getters
+
+- (BOOL)isAuthorizationGranted {
+    switch (CLLocationManager.authorizationStatus) {
+        case kCLAuthorizationStatusAuthorizedAlways:
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            return YES;
+
+        default:
+            return NO;
     }
 }
 
-- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
-    [self enrichWithLocation:self.lastKnownLocation];
+- (BOOL)shouldRequestLocation {
+    BOOL areLocationServicesEnabled = CLLocationManager.locationServicesEnabled;
+    return areLocationServicesEnabled && self.isAuthorizationGranted;
+}
+
+- (BOOL)shouldEnrichTransaction:(JPTransaction *)transaction {
+    return [self.enricheablePaths containsObject:transaction.transactionPath];
+}
+
+#pragma mark - Lazy properties
+
+- (NSArray *)enricheablePaths {
+    if (!_enricheablePaths) {
+        _enricheablePaths = @[ @"transactions/payments",
+                               @"transactions/preauths",
+                               @"transactions/registercard",
+                               @"transactions/checkcard" ];
+    }
+    return _enricheablePaths;
+}
+
+- (CLLocationManager *)locationManager {
+    if (!_locationManager) {
+        _locationManager = [CLLocationManager new];
+        _locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters;
+        _locationManager.delegate = self;
+    }
+    return _locationManager;
 }
 
 - (CLLocation *)lastKnownLocation {
     if (!_lastKnownLocation) {
-        _lastKnownLocation = [[CLLocation alloc] initWithLatitude:0.0 longitude:0.0];
+        _lastKnownLocation = [[CLLocation alloc] initWithLatitude:0.0
+                                                        longitude:0.0];
     }
     return _lastKnownLocation;
+}
+
+#pragma mark - CLLocationManagerDelegate
+
+- (void)locationManager:(CLLocationManager *)manager
+     didUpdateLocations:(NSArray<CLLocation *> *)locations {
+
+    if (locations.count > 0) {
+        self.lastKnownLocation = locations.lastObject;
+    }
+}
+
+- (void)locationManager:(CLLocationManager *)manager
+       didFailWithError:(NSError *)error {
+    // Location fetch failed, do nothing :(
 }
 
 @end

--- a/Source/Services/Transaction/JPTransactionService.m
+++ b/Source/Services/Transaction/JPTransactionService.m
@@ -73,7 +73,6 @@
     }
 
     JPTransaction *transaction = [JPTransaction transactionWithType:self.transactionType];
-
     transaction.judoId = configuration.judoId;
     transaction.amount = configuration.amount;
     transaction.reference = configuration.reference;


### PR DESCRIPTION
### Root cause:
1. Transactions have to be enriched before being sent to the backend;
2. For enrichment to work, the location must be provided;
3. Old implementation called `[self.locationManager requestLocation]` for each new transaction _(each time the user taps on a Pay button)_;
4. Due to the nature of the `requestLocation` nature, this process would take up to 10 seconds if the location could not be fetched;

### Other side effects:
1. In `[locationManager: didUpdateLocation:]` a call is sent to the DeviceDNA with the location, triggering the enrichment process and continuing the payment request. 
2. The way `requestLocation` works is by sending multiple callbacks to `[locationManager: didUpdateLocation:]`, each with increased accuracy.
3. This, in turn, causes multiple calls to the DeviceDNA backend, which in turn results in multiple payment requests. _(The duplicate transaction was an issue a couple of months ago, but was "fixed" with a boolean flag stopping updates)_

### Resolution
1. `requestLocation` is called once, when the `JPTransactionEnricher` object is initialized. The `JPTransactionEnricher` object is initialized as part of the JudoKit SDK initialization, so the location is obtained as soon as possible;

### Other investigation results:
- DeviceDNA doesn't work at all. 
It sends a POST request to `https://genome.judopay.com/api/v1/device/`, which returns an error stating that `A server with the specified hostname could not be found.`;