### PR TITLE
[Bugfix] Payment Method sections don't match payment type

### DIFF
--- a/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
+++ b/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
@@ -48,8 +48,12 @@
 @property (nonatomic, strong) JPPaymentMethodsIDEALBankListModel *bankListModel;
 @property (nonatomic, strong) JPTransactionButtonViewModel *paymentButtonModel;
 
-@property (nonatomic, assign) NSUInteger previousIndex;
+@property (nonatomic, assign) NSUInteger previousSectionIndex;
+@property (nonatomic, assign) NSUInteger selectedSectionIndex;
+
 @property (nonatomic, assign) NSUInteger selectedBankIndex;
+@property (nonatomic, strong) NSArray<JPPaymentMethod *> *paymentMethods;
+
 @end
 
 @implementation JPPaymentMethodsPresenterImpl
@@ -195,23 +199,25 @@
 
 - (void)changePaymentMethodToIndex:(NSUInteger)index {
 
-    if (index == self.previousIndex) {
+    if (index == self.previousSectionIndex) {
         return;
     }
 
     AnimationType animationType = AnimationTypeLeftToRight;
 
-    if (index < self.previousIndex) {
+    if (index < self.previousSectionIndex) {
         animationType = AnimationTypeRightToLeft;
     }
 
-    JPPaymentMethod *previousMethod = self.paymentSelectionModel.paymentMethods[self.previousIndex];
+    JPPaymentMethod *previousMethod = self.paymentSelectionModel.paymentMethods[self.previousSectionIndex];
     if (previousMethod.type == JPPaymentMethodTypeCard && self.cardListModel.cardModels.count == 0) {
         animationType = AnimationTypeSetup;
     }
 
-    self.previousIndex = index;
-    self.paymentSelectionModel.selectedPaymentMethod = index;
+    self.previousSectionIndex = index;
+    self.selectedSectionIndex = index;
+    
+    self.paymentSelectionModel.selectedPaymentMethod = self.paymentMethods[index].type;
 
     [self viewModelNeedsUpdateWithAnimationType:animationType
                             shouldAnimateChange:YES];
@@ -257,20 +263,16 @@
 
 - (void)preparePaymentMethodModels {
 
-    NSArray *paymentMethods = [self.interactor getPaymentMethods];
-    self.paymentSelectionModel.paymentMethods = paymentMethods;
+    self.paymentSelectionModel.paymentMethods = self.paymentMethods;
 
     if (paymentMethods.count > 1) {
         [self.viewModel.items addObject:self.paymentSelectionModel];
     }
 
-    NSUInteger selectedPaymentIndex = self.paymentSelectionModel.selectedPaymentMethod;
-    JPPaymentMethod *selectedPaymentMethod = self.paymentSelectionModel.paymentMethods[selectedPaymentIndex];
-
-    self.viewModel.headerModel.paymentMethodType = selectedPaymentMethod.type;
+    self.viewModel.headerModel.paymentMethodType = self.paymentSelectionModel.selectedPaymentMethod;
     self.viewModel.headerModel.isApplePaySetUp = [self.interactor isApplePaySetUp];
 
-    switch (selectedPaymentMethod.type) {
+    switch (self.paymentSelectionModel.selectedPaymentMethod) {
         case JPPaymentMethodTypeCard:
             [self prepareCardListModels];
             break;
@@ -402,6 +404,7 @@
     if (!_paymentSelectionModel) {
         _paymentSelectionModel = [JPPaymentMethodsSelectionModel new];
         _paymentSelectionModel.identifier = @"JPPaymentMethodsSelectionCell";
+        _paymentSelectionModel.selectedPaymentMethod = self.paymentMethods.firstObject.type;
     }
     return _paymentSelectionModel;
 }
@@ -477,6 +480,13 @@
         _bankListModel.identifier = @"JPPaymentMethodsIDEALBankCell";
     }
     return _bankListModel;
+}
+
+- (NSArray<JPPaymentMethod *> *)paymentMethods {
+    if (!_paymentMethods) {
+        _paymentMethods = [self.interactor getPaymentMethods];
+    }
+    return _paymentMethods;
 }
 
 @end

--- a/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
+++ b/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
@@ -216,7 +216,8 @@
 
     self.previousSectionIndex = index;
     self.selectedSectionIndex = index;
-    
+
+    self.paymentSelectionModel.selectedIndex = index;
     self.paymentSelectionModel.selectedPaymentMethod = self.paymentMethods[index].type;
 
     [self viewModelNeedsUpdateWithAnimationType:animationType
@@ -265,7 +266,7 @@
 
     self.paymentSelectionModel.paymentMethods = self.paymentMethods;
 
-    if (paymentMethods.count > 1) {
+    if (self.paymentMethods.count > 1) {
         [self.viewModel.items addObject:self.paymentSelectionModel];
     }
 

--- a/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsViewModel.h
+++ b/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsViewModel.h
@@ -55,7 +55,12 @@ typedef NS_ENUM(NSUInteger, AnimationType) {
 /**
  * The index of the currently selected payment method
  */
-@property (nonatomic, assign) NSUInteger selectedPaymentMethod;
+@property (nonatomic, assign) NSUInteger selectedIndex;
+
+/**
+ * The type of the currently selected payment method
+ */
+@property (nonatomic, assign) JPPaymentMethodType selectedPaymentMethod;
 
 /**
  * An array of available payment methods

--- a/Source/Modules/PaymentMethods/View/Subviews/CardView/JPOtherPaymentMethodView.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/CardView/JPOtherPaymentMethodView.m
@@ -87,7 +87,7 @@ static const float kContentPadding = 28.0f;
     switch (viewModel.paymentMethodType) {
         case JPPaymentMethodTypeApplePay:
             self.leadingImageView.image = [UIImage imageWithIconName:@"apple-pay-icon"];
-            self.titleLabel.text = @"apple-pay".localized;
+            self.titleLabel.text = @"apple_pay".localized;
             break;
 
         case JPPaymentMethodTypeIDeal:

--- a/Source/Modules/PaymentMethods/View/Subviews/Cells/PaymentMethodSelectionCell/JPPaymentMethodsSelectionCell.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/Cells/PaymentMethodSelectionCell/JPPaymentMethodsSelectionCell.m
@@ -90,7 +90,7 @@ static const int kConstraintPriority = 999;
     [self setupSectionViewWithSections:sections];
 
     if (selectionModel.selectedPaymentMethod != 0) {
-        [self.sectionView switchToSectionAtIndex:selectionModel.selectedPaymentMethod];
+        [self.sectionView switchToSectionAtIndex:selectionModel.selectedIndex];
     }
 }
 


### PR DESCRIPTION
# Bug Description:
Changing the default order of the payment causes the sections to display incorrectly and trigger the wrong logic. (_ex. paying with iDEAL will trigger a card transaction_).

# Root Cause:
This is due to a wrong setting that sets the selected payment method type from the section index
```objc
self.paymentSelectionModel.selectedPaymentMethod = sectionIndex;
```

A correct call would be like so:
```objc
JPPaymentMethod *selectedPaymentMethod = self.paymentMethods[sectionIndex];
self.paymentSelectionModel.selectedPaymentMethod = selectedPaymentMethod.type;
```

# Changelog:
- Updated logic so that section indexes are separate from selected section types;
- Fixed a wrong localization for Apple Pay;

# Demo Video:
https://drive.google.com/open?id=1eBUXTChw5TadJgNVax9letv-KhPmcAkl
