### PR TITLE
EP-837 [iOS] Rewrite security code logic and use the correct placeholder/hint

### DIFF
--- a/Source/Models/CardNetwork/JPCardNetwork.h
+++ b/Source/Models/CardNetwork/JPCardNetwork.h
@@ -38,11 +38,6 @@
 @property (nonatomic, assign) CardNetwork network;
 
 /**
- * An integer specifying the security code length for the current network
- */
-@property (nonatomic, assign) NSUInteger securityCodeLength;
-
-/**
  * An instance of NSString that returns the card format for the current network
  */
 @property (nonatomic, strong) NSString *numberPattern;
@@ -70,7 +65,6 @@
  */
 + (instancetype)networkWith:(CardNetwork)type
              numberPrefixes:(NSString *)prefixes
-         securityCodeLength:(NSUInteger)length
               numberPattern:(NSString *)pattern;
 
 /**
@@ -109,4 +103,10 @@
  * A getter that returns the default number pattern
  */
 + (NSString *)defaultNumberPattern;
+
+/**
+ * An integer specifying the security code length for the network type
+ */
++ (NSUInteger)securityCodeLength:(CardNetwork)networkType;
+
 @end

--- a/Source/Models/CardNetwork/JPCardNetwork.h
+++ b/Source/Models/CardNetwork/JPCardNetwork.h
@@ -106,12 +106,20 @@
 
 /**
  * An integer specifying the security code length for the network type
+ *
+ * @param networkType - the card network type
+ *
+ * @returns the card network security code length;
  */
-+ (NSUInteger)securityCodeLength:(CardNetwork)networkType;
++ (NSUInteger)secureCodeLengthForNetworkType:(CardNetwork)networkType;
 
 /**
  * String specifying the security code placeholder
+ *
+ * @param networkType - the card network type
+ *
+ * @returns the card network security code placeholder;
  */
-+ (NSString *)securityCodePlaceholder:(CardNetwork)networkType;
++ (NSString *)secureCodePlaceholderForNetworkType:(CardNetwork)networkType;
 
 @end

--- a/Source/Models/CardNetwork/JPCardNetwork.h
+++ b/Source/Models/CardNetwork/JPCardNetwork.h
@@ -109,4 +109,9 @@
  */
 + (NSUInteger)securityCodeLength:(CardNetwork)networkType;
 
+/**
+ * String specifying the security code placeholder
+ */
++ (NSString *)securityCodePlaceholder:(CardNetwork)networkType;
+
 @end

--- a/Source/Models/CardNetwork/JPCardNetwork.m
+++ b/Source/Models/CardNetwork/JPCardNetwork.m
@@ -27,23 +27,19 @@
 #import "NSArray+Additions.h"
 
 @implementation JPCardNetwork
-
 + (instancetype)networkWith:(CardNetwork)type
              numberPrefixes:(NSString *)prefixes {
     return [JPCardNetwork networkWith:type
                        numberPrefixes:prefixes
-                   securityCodeLength:3
                         numberPattern:[self defaultNumberPattern]];
 }
 
 + (instancetype)networkWith:(CardNetwork)type
              numberPrefixes:(NSString *)prefixes
-         securityCodeLength:(NSUInteger)length
               numberPattern:(NSString *)pattern {
     JPCardNetwork *network = [JPCardNetwork new];
     network.network = type;
     network.numberPrefixes = [prefixes componentsSeparatedByString:@","];
-    network.securityCodeLength = length;
     network.numberPattern = pattern;
     return network;
 }
@@ -81,7 +77,6 @@
 
             [JPCardNetwork networkWith:CardNetworkAMEX
                         numberPrefixes:kAMEXPrefixes
-                    securityCodeLength:4
                          numberPattern:kAMEXPattern],
 
             [JPCardNetwork networkWith:CardNetworkMaestro
@@ -89,7 +84,6 @@
 
             [JPCardNetwork networkWith:CardNetworkDinersClub
                         numberPrefixes:kDinersClubPrefixes
-                    securityCodeLength:3
                          numberPattern:kDinersClubPattern],
 
             [JPCardNetwork networkWith:CardNetworkJCB
@@ -147,6 +141,15 @@
         return names[key];
     }
     return names[@(CardNetworkUnknown)];
+}
+
++ (NSUInteger)securityCodeLength:(CardNetwork)networkType {
+    switch (networkType) {
+        case CardNetworkAMEX:
+            return kSecurityCodeLengthAmex;
+        default:
+            return kSecurityCodeLengthDefault;
+    }
 }
 
 @end

--- a/Source/Models/CardNetwork/JPCardNetwork.m
+++ b/Source/Models/CardNetwork/JPCardNetwork.m
@@ -143,7 +143,7 @@
     return names[@(CardNetworkUnknown)];
 }
 
-+ (NSUInteger)securityCodeLength:(CardNetwork)networkType {
++ (NSUInteger)secureCodeLengthForNetworkType:(CardNetwork)networkType {
     switch (networkType) {
         case CardNetworkAMEX:
             return kSecurityCodeLengthAmex;
@@ -152,7 +152,7 @@
     }
 }
 
-+ (NSString *)securityCodePlaceholder:(CardNetwork)networkType {
++ (NSString *)secureCodePlaceholderForNetworkType:(CardNetwork)networkType {
     switch (networkType) {
         case CardNetworkAMEX:
             return kSecurityCodePlaceholderhAmex;

--- a/Source/Models/CardNetwork/JPCardNetwork.m
+++ b/Source/Models/CardNetwork/JPCardNetwork.m
@@ -152,4 +152,21 @@
     }
 }
 
++ (NSString *)securityCodePlaceholder:(CardNetwork)networkType {
+    switch (networkType) {
+        case CardNetworkAMEX:
+            return kSecurityCodePlaceholderhAmex;
+        case CardNetworkVisa:
+            return kSecurityCodePlaceholderhVisa;
+        case CardNetworkMasterCard:
+            return kSecurityCodePlaceholderhMasterCard;
+        case CardNetworkChinaUnionPay:
+            return kSecurityCodePlaceholderhChinaUnionPay;
+        case CardNetworkJCB:
+            return kSecurityCodePlaceholderhJCB;
+        default:
+            return kSecurityCodePlaceholderDefault;
+    }
+}
+
 @end

--- a/Source/Models/Constants/JPConstants.h
+++ b/Source/Models/Constants/JPConstants.h
@@ -53,4 +53,7 @@ static NSString *const kMonthYearDateFormat = @"MM/yy";
 static NSString *const kCurrencyEuro = @"EUR";
 static NSString *const kFailureReasonUserAbort = @"USER_ABORT";
 
+static NSUInteger const kSecurityCodeLengthAmex = 4;
+static NSUInteger const kSecurityCodeLengthDefault = 3;
+
 #endif /* JPConstants_h */

--- a/Source/Models/Constants/JPConstants.h
+++ b/Source/Models/Constants/JPConstants.h
@@ -56,4 +56,11 @@ static NSString *const kFailureReasonUserAbort = @"USER_ABORT";
 static NSUInteger const kSecurityCodeLengthAmex = 4;
 static NSUInteger const kSecurityCodeLengthDefault = 3;
 
+static NSString *const kSecurityCodePlaceholderhAmex = @"CID";
+static NSString *const kSecurityCodePlaceholderhVisa = @"CVV2";
+static NSString *const kSecurityCodePlaceholderhMasterCard = @"CVC2";
+static NSString *const kSecurityCodePlaceholderhChinaUnionPay = @"CVN2";
+static NSString *const kSecurityCodePlaceholderhJCB = @"CAV2";
+static NSString *const kSecurityCodePlaceholderDefault = @"CVV";
+
 #endif /* JPConstants_h */

--- a/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
+++ b/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
@@ -264,7 +264,7 @@
     self.addCardViewModel.cardNumberViewModel.errorText = result.errorMessage;
     self.isCardNumberValid = result.isValid;
 
-    [self updateSecureCodeViewModelPlaceholderIfNeed:result.cardNetwork];
+    [self updateSecureCodePlaceholderForNetworkType:result.cardNetwork];
 
     if (result.isInputAllowed) {
         self.addCardViewModel.cardNumberViewModel.text = result.formattedInput;
@@ -273,9 +273,9 @@
     }
 }
 
-- (void)updateSecureCodeViewModelPlaceholderIfNeed:(CardNetwork)cardNetwork {
+- (void)updateSecureCodePlaceholderForNetworkType:(CardNetwork)cardNetwork {
     if (self.addCardViewModel.cardNumberViewModel.cardNetwork != cardNetwork) {
-        NSString *placeholder = [JPCardNetwork securityCodePlaceholder:cardNetwork];
+        NSString *placeholder = [JPCardNetwork secureCodePlaceholderForNetworkType:cardNetwork];
         self.addCardViewModel.secureCodeViewModel.placeholder = placeholder;
     }
 }

--- a/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
+++ b/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
@@ -264,10 +264,19 @@
     self.addCardViewModel.cardNumberViewModel.errorText = result.errorMessage;
     self.isCardNumberValid = result.isValid;
 
+    [self updateSecureCodeViewModelPlaceholderIfNeed:result.cardNetwork];
+
     if (result.isInputAllowed) {
         self.addCardViewModel.cardNumberViewModel.text = result.formattedInput;
         self.addCardViewModel.cardNumberViewModel.cardNetwork = result.cardNetwork;
         return;
+    }
+}
+
+- (void)updateSecureCodeViewModelPlaceholderIfNeed:(CardNetwork)cardNetwork {
+    if (self.addCardViewModel.cardNumberViewModel.cardNetwork != cardNetwork) {
+        NSString *placeholder = [JPCardNetwork securityCodePlaceholder:cardNetwork];
+        self.addCardViewModel.secureCodeViewModel.placeholder = placeholder;
     }
 }
 

--- a/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
+++ b/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
@@ -310,11 +310,7 @@
     JPValidationResult *result = [self.interactor validateSecureCodeInput:input];
     self.addCardViewModel.secureCodeViewModel.errorText = result.errorMessage;
     self.isSecureCodeValid = result.isValid;
-
-    if (result.isInputAllowed) {
-        self.addCardViewModel.secureCodeViewModel.text = result.formattedInput;
-        return;
-    }
+    self.addCardViewModel.secureCodeViewModel.text = result.formattedInput;
 }
 
 - (void)updateCountryViewModelForInput:(NSString *)input {

--- a/Source/Services/CardValidation/JPCardValidationService.m
+++ b/Source/Services/CardValidation/JPCardValidationService.m
@@ -34,7 +34,6 @@
 
 @property (nonatomic, strong) JPValidationResult *lastCardNumberValidationResult;
 @property (nonatomic, strong) JPValidationResult *lastExpiryDateValidationResult;
-@property (nonatomic, strong) JPValidationResult *lastSecureCodeValidationResult;
 @property (nonatomic, strong) JPValidationResult *lastPostalCodeValidationResult;
 @property (nonatomic, strong) NSString *selectedJPBillingCountry;
 @end
@@ -46,7 +45,6 @@
 - (void)resetCardValidationResults {
     self.lastCardNumberValidationResult = nil;
     self.lastExpiryDateValidationResult = nil;
-    self.lastSecureCodeValidationResult = nil;
     self.lastPostalCodeValidationResult = nil;
 }
 
@@ -170,26 +168,11 @@
 }
 
 - (JPValidationResult *)validateSecureCodeInput:(NSString *)input {
-
-    JPCardNetwork *cardNetwork = [JPCardNetwork cardNetworkWithType:self.lastCardNumberValidationResult.cardNetwork];
-
-    if (cardNetwork == CardNetworkUnknown) {
-        self.lastSecureCodeValidationResult = [JPValidationResult validationWithResult:input.length == 3
-                                                                          inputAllowed:input.length <= 3
-                                                                          errorMessage:nil
-                                                                        formattedInput:input];
-        return self.lastSecureCodeValidationResult;
-    }
-
-    if (input.length > cardNetwork.securityCodeLength) {
-        return self.lastSecureCodeValidationResult;
-    }
-
-    self.lastSecureCodeValidationResult = [JPValidationResult validationWithResult:input.length == cardNetwork.securityCodeLength
-                                                                      inputAllowed:input.length <= cardNetwork.securityCodeLength
-                                                                      errorMessage:nil
-                                                                    formattedInput:input];
-    return self.lastSecureCodeValidationResult;
+    NSUInteger securityCodeLength = [JPCardNetwork securityCodeLength: self.lastCardNumberValidationResult.cardNetwork];
+    return [JPValidationResult validationWithResult:input.length == securityCodeLength
+                                       inputAllowed:input.length <= securityCodeLength
+                                       errorMessage:nil
+                                     formattedInput:input];
 }
 
 - (JPValidationResult *)validateCountryInput:(NSString *)input {

--- a/Source/Services/CardValidation/JPCardValidationService.m
+++ b/Source/Services/CardValidation/JPCardValidationService.m
@@ -168,7 +168,7 @@
 }
 
 - (JPValidationResult *)validateSecureCodeInput:(NSString *)input {
-    NSUInteger securityCodeLength = [JPCardNetwork securityCodeLength:self.lastCardNumberValidationResult.cardNetwork];
+    NSUInteger securityCodeLength = [JPCardNetwork secureCodeLengthForNetworkType:self.lastCardNumberValidationResult.cardNetwork];
     return [JPValidationResult validationWithResult:input.length == securityCodeLength
                                        inputAllowed:input.length <= securityCodeLength
                                        errorMessage:nil

--- a/Source/Services/CardValidation/JPCardValidationService.m
+++ b/Source/Services/CardValidation/JPCardValidationService.m
@@ -169,10 +169,12 @@
 
 - (JPValidationResult *)validateSecureCodeInput:(NSString *)input {
     NSUInteger securityCodeLength = [JPCardNetwork secureCodeLengthForNetworkType:self.lastCardNumberValidationResult.cardNetwork];
-    return [JPValidationResult validationWithResult:input.length == securityCodeLength
-                                       inputAllowed:input.length <= securityCodeLength
+    NSString *formatedInput = [input substringToIndex:MIN(input.length, securityCodeLength)];
+    
+    return [JPValidationResult validationWithResult:formatedInput.length == securityCodeLength
+                                       inputAllowed:formatedInput.length <= securityCodeLength
                                        errorMessage:nil
-                                     formattedInput:input];
+                                     formattedInput:formatedInput];
 }
 
 - (JPValidationResult *)validateCountryInput:(NSString *)input {

--- a/Source/Services/CardValidation/JPCardValidationService.m
+++ b/Source/Services/CardValidation/JPCardValidationService.m
@@ -168,7 +168,7 @@
 }
 
 - (JPValidationResult *)validateSecureCodeInput:(NSString *)input {
-    NSUInteger securityCodeLength = [JPCardNetwork securityCodeLength: self.lastCardNumberValidationResult.cardNetwork];
+    NSUInteger securityCodeLength = [JPCardNetwork securityCodeLength:self.lastCardNumberValidationResult.cardNetwork];
     return [JPValidationResult validationWithResult:input.length == securityCodeLength
                                        inputAllowed:input.length <= securityCodeLength
                                        errorMessage:nil


### PR DESCRIPTION
refactor logic of securityCodeLength in cardValidationService.
Add constants for Amex & Default cards.
Update JPCardNetwork with securityCodeLength implementation. remove securityCodeLength from old init method (so we need that method? it is not used?!)