### PR TITLE
Fixed Apple Pay not working for the new SDK

### DIFF
--- a/JudoKitObjCExampleApp/Controllers/Main/MainViewController.m
+++ b/JudoKitObjCExampleApp/Controllers/Main/MainViewController.m
@@ -124,7 +124,7 @@ static NSString * const kConsumerReference = @"judoPay-sample-app-objc";
 - (void)applePayPaymentOperation {
     __weak typeof(self) weakSelf = self;
     [self.judoKitSession invokeApplePayWithMode:TransactionModePayment
-                                  configuration:self.applePayConfiguration
+                                  configuration:self.configuration
                                      completion:^(JPResponse *response, NSError *error) {
         [weakSelf handleResponse:response];
     }];
@@ -133,7 +133,7 @@ static NSString * const kConsumerReference = @"judoPay-sample-app-objc";
 - (void)applePayPreAuthOperation {
     __weak typeof(self) weakSelf = self;
     [self.judoKitSession invokeApplePayWithMode:TransactionModePreAuth
-                                  configuration:self.applePayConfiguration
+                                  configuration:self.configuration
                                      completion:^(JPResponse *response, NSError *error) {
         [weakSelf handleResponse:response];
     }];

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -94,7 +94,7 @@ static NSString *__nonnull const JudoKitVersion = @"8.2.1";
  * @param completion - a completion block with an optional JPResponse object or an NSError.
  */
 - (void)invokeApplePayWithMode:(TransactionMode)mode
-                 configuration:(nonnull JPApplePayConfiguration *)configuration
+                 configuration:(nonnull JPConfiguration *)configuration
                     completion:(nullable JudoCompletionBlock)completion;
 
 /**

--- a/Source/JudoKit.m
+++ b/Source/JudoKit.m
@@ -98,7 +98,7 @@
 }
 
 - (void)invokeApplePayWithMode:(TransactionMode)mode
-                 configuration:(JPApplePayConfiguration *)configuration
+                 configuration:(JPConfiguration *)configuration
                     completion:(JudoCompletionBlock)completion {
     self.applePayService = [[JPApplePayService alloc] initWithConfiguration:configuration
                                                          transactionService:self.transactionService];

--- a/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.m
+++ b/Source/Modules/PaymentMethods/Interactor/JPPaymentMethodsInteractor.m
@@ -208,7 +208,7 @@
 
 - (JPApplePayService *)applePayService {
     if (!_applePayService && self.configuration.applePayConfiguration) {
-        _applePayService = [[JPApplePayService alloc] initWithConfiguration:self.configuration.applePayConfiguration
+        _applePayService = [[JPApplePayService alloc] initWithConfiguration:self.configuration
                                                          transactionService:self.transactionService];
     }
     return _applePayService;

--- a/Source/Services/ApplePay/JPApplePayService.h
+++ b/Source/Services/ApplePay/JPApplePayService.h
@@ -39,7 +39,7 @@
  *
  * @returns - a configured instance of JPApplePayService.
  */
-- (nonnull instancetype)initWithConfiguration:(nonnull JPApplePayConfiguration *)configuration
+- (nonnull instancetype)initWithConfiguration:(nonnull JPConfiguration *)configuration
                            transactionService:(nonnull JPTransactionService *)transactionService;
 
 /**


### PR DESCRIPTION
# Changelog:

- Fixed a really stupid bug of passing an empty configuration to the transaction service for Apple Pay transactions;
- Has been successfully tested by Wilson in production. Everything works fine now;