### PR TITLE
Small improvements & JPError changes

### DIFF
--- a/JudoKitObjC.xcodeproj/project.pbxproj
+++ b/JudoKitObjC.xcodeproj/project.pbxproj
@@ -48,8 +48,8 @@
 		30006F9123F6993A0099F3C5 /* NSString+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30006F6E23F6993A0099F3C5 /* NSString+Additions.h */; };
 		30006F9223F6993A0099F3C5 /* UIViewController+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30006F7023F6993A0099F3C5 /* UIViewController+Additions.h */; };
 		30006F9323F6993A0099F3C5 /* UIViewController+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 30006F7123F6993A0099F3C5 /* UIViewController+Additions.m */; };
-		30006F9423F6993A0099F3C5 /* NSError+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 30006F7323F6993A0099F3C5 /* NSError+Additions.m */; };
-		30006F9523F6993A0099F3C5 /* NSError+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30006F7423F6993A0099F3C5 /* NSError+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		30006F9423F6993A0099F3C5 /* JPError+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 30006F7323F6993A0099F3C5 /* JPError+Additions.m */; };
+		30006F9523F6993A0099F3C5 /* JPError+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30006F7423F6993A0099F3C5 /* JPError+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		30006F9623F6993A0099F3C5 /* NSArray+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30006F7623F6993A0099F3C5 /* NSArray+Additions.h */; };
 		30006F9723F6993A0099F3C5 /* NSArray+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 30006F7723F6993A0099F3C5 /* NSArray+Additions.m */; };
 		30006F9823F6993A0099F3C5 /* UIImage+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 30006F7923F6993A0099F3C5 /* UIImage+Additions.h */; };
@@ -184,6 +184,8 @@
 		30221C9123FFC53600BF2823 /* JPCardPattern.m in Sources */ = {isa = PBXBuildFile; fileRef = 30221C8F23FFC53600BF2823 /* JPCardPattern.m */; };
 		30221CBE24040F4D00BF2823 /* JPCardCustomizationTextInputCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 30221CBC24040F4D00BF2823 /* JPCardCustomizationTextInputCell.h */; };
 		30221CBF24040F4D00BF2823 /* JPCardCustomizationTextInputCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 30221CBD24040F4D00BF2823 /* JPCardCustomizationTextInputCell.m */; };
+		30489AD62460738B0085B4F2 /* JPError.h in Headers */ = {isa = PBXBuildFile; fileRef = 30489AD42460738B0085B4F2 /* JPError.h */; };
+		30489AD72460738B0085B4F2 /* JPError.m in Sources */ = {isa = PBXBuildFile; fileRef = 30489AD52460738B0085B4F2 /* JPError.m */; };
 		3058351E2406583400B61167 /* JPCardCustomizationSubmitCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 305835152406583400B61167 /* JPCardCustomizationSubmitCell.h */; };
 		3058351F2406583400B61167 /* JPCardCustomizationSubmitCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 305835162406583400B61167 /* JPCardCustomizationSubmitCell.m */; };
 		305835232406586C00B61167 /* JPCardCustomizationIsDefaultCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 305835212406586C00B61167 /* JPCardCustomizationIsDefaultCell.m */; };
@@ -354,8 +356,8 @@
 		30006F6E23F6993A0099F3C5 /* NSString+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Additions.h"; sourceTree = "<group>"; };
 		30006F7023F6993A0099F3C5 /* UIViewController+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Additions.h"; sourceTree = "<group>"; };
 		30006F7123F6993A0099F3C5 /* UIViewController+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Additions.m"; sourceTree = "<group>"; };
-		30006F7323F6993A0099F3C5 /* NSError+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+Additions.m"; sourceTree = "<group>"; };
-		30006F7423F6993A0099F3C5 /* NSError+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+Additions.h"; sourceTree = "<group>"; };
+		30006F7323F6993A0099F3C5 /* JPError+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "JPError+Additions.m"; sourceTree = "<group>"; };
+		30006F7423F6993A0099F3C5 /* JPError+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JPError+Additions.h"; sourceTree = "<group>"; };
 		30006F7623F6993A0099F3C5 /* NSArray+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+Additions.h"; sourceTree = "<group>"; };
 		30006F7723F6993A0099F3C5 /* NSArray+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Additions.m"; sourceTree = "<group>"; };
 		30006F7923F6993A0099F3C5 /* UIImage+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Additions.h"; sourceTree = "<group>"; };
@@ -490,6 +492,8 @@
 		30221C8F23FFC53600BF2823 /* JPCardPattern.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JPCardPattern.m; sourceTree = "<group>"; };
 		30221CBC24040F4D00BF2823 /* JPCardCustomizationTextInputCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JPCardCustomizationTextInputCell.h; sourceTree = "<group>"; };
 		30221CBD24040F4D00BF2823 /* JPCardCustomizationTextInputCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JPCardCustomizationTextInputCell.m; sourceTree = "<group>"; };
+		30489AD42460738B0085B4F2 /* JPError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JPError.h; sourceTree = "<group>"; };
+		30489AD52460738B0085B4F2 /* JPError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JPError.m; sourceTree = "<group>"; };
 		305835152406583400B61167 /* JPCardCustomizationSubmitCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JPCardCustomizationSubmitCell.h; sourceTree = "<group>"; };
 		305835162406583400B61167 /* JPCardCustomizationSubmitCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPCardCustomizationSubmitCell.m; sourceTree = "<group>"; };
 		305835212406586C00B61167 /* JPCardCustomizationIsDefaultCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPCardCustomizationIsDefaultCell.m; sourceTree = "<group>"; };
@@ -855,14 +859,14 @@
 			path = Extensions/UIViewController;
 			sourceTree = "<group>";
 		};
-		30006F7223F6993A0099F3C5 /* NSError */ = {
+		30006F7223F6993A0099F3C5 /* JPError */ = {
 			isa = PBXGroup;
 			children = (
-				30006F7423F6993A0099F3C5 /* NSError+Additions.h */,
-				30006F7323F6993A0099F3C5 /* NSError+Additions.m */,
+				30006F7423F6993A0099F3C5 /* JPError+Additions.h */,
+				30006F7323F6993A0099F3C5 /* JPError+Additions.m */,
 			);
-			name = NSError;
-			path = Extensions/NSError;
+			name = JPError;
+			path = Extensions/JPError;
 			sourceTree = "<group>";
 		};
 		30006F7523F6993A0099F3C5 /* NSArray */ = {
@@ -948,6 +952,7 @@
 		300071C523F6A78E0099F3C5 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				30489AD32460737A0085B4F2 /* Error */,
 				3000737923FBECCE0099F3C5 /* 3DSConfiguration */,
 				3000728F23F6AB550099F3C5 /* Address */,
 				3000726223F6AB540099F3C5 /* Amount */,
@@ -1544,6 +1549,15 @@
 			path = CardCustomizationTextInputCell;
 			sourceTree = "<group>";
 		};
+		30489AD32460737A0085B4F2 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				30489AD42460738B0085B4F2 /* JPError.h */,
+				30489AD52460738B0085B4F2 /* JPError.m */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		305835142406583400B61167 /* CardCustomizationSubmitCell */ = {
 			isa = PBXGroup;
 			children = (
@@ -1777,7 +1791,7 @@
 				30006F8723F6993A0099F3C5 /* CLLocation */,
 				30006F7523F6993A0099F3C5 /* NSArray */,
 				30006F8123F6993A0099F3C5 /* NSBundle */,
-				30006F7223F6993A0099F3C5 /* NSError */,
+				30006F7223F6993A0099F3C5 /* JPError */,
 				30221C0D23FE617300BF2823 /* NSLayoutConstraint */,
 				30006F6C23F6993A0099F3C5 /* NSString */,
 				30006F7B23F6993A0099F3C5 /* UIApplication */,
@@ -2032,6 +2046,7 @@
 				300072F223F6AB560099F3C5 /* JPClientDetails.h in Headers */,
 				30221C9023FFC53600BF2823 /* JPCardPattern.h in Headers */,
 				52B74D9623F98B4C009FE38C /* JPCardInputField.h in Headers */,
+				30489AD62460738B0085B4F2 /* JPError.h in Headers */,
 				300072C423F6AB560099F3C5 /* JPAmount.h in Headers */,
 				30006FA223F6993A0099F3C5 /* CLLocation+Additions.h in Headers */,
 				300072C923F6AB560099F3C5 /* JPConfiguration.h in Headers */,
@@ -2115,7 +2130,7 @@
 				30221C4823FE7D7100BF2823 /* JPCardCustomizable.h in Headers */,
 				300072DB23F6AB560099F3C5 /* JPOrderDetails.h in Headers */,
 				30006F2123F6971B0099F3C5 /* JPSliderPresentationController.h in Headers */,
-				30006F9523F6993A0099F3C5 /* NSError+Additions.h in Headers */,
+				30006F9523F6993A0099F3C5 /* JPError+Additions.h in Headers */,
 				30221C5323FE7F6300BF2823 /* JPCardCustomizationHeaderCell.h in Headers */,
 				300072BA23F6AB560099F3C5 /* JPPaymentMethods.h in Headers */,
 				300072EE23F6AB560099F3C5 /* JPCardNetwork.h in Headers */,
@@ -2289,7 +2304,7 @@
 				30006F9923F6993A0099F3C5 /* UIImage+Additions.m in Sources */,
 				5273AF1A23F31027008C6D89 /* JPOtherPaymentMethodView.m in Sources */,
 				300072FA23F6AB560099F3C5 /* JPStoredCardDetails.m in Sources */,
-				30006F9423F6993A0099F3C5 /* NSError+Additions.m in Sources */,
+				30006F9423F6993A0099F3C5 /* JPError+Additions.m in Sources */,
 				30D61D5923BB741A004E5CEE /* JPPaymentMethodsViewController.m in Sources */,
 				30D61D6323BB741A004E5CEE /* JPPaymentMethodsCardListHeaderCell.m in Sources */,
 				3000733423FA9C1C0099F3C5 /* JPSession.m in Sources */,
@@ -2343,6 +2358,7 @@
 				529CCB8E23BE8AA300A8DBDD /* JPPaymentMethodsEmptyHeaderView.m in Sources */,
 				30D61D5623BB741A004E5CEE /* JPPaymentMethodsPresenter.m in Sources */,
 				300072DC23F6AB560099F3C5 /* JPOrderDetails.m in Sources */,
+				30489AD72460738B0085B4F2 /* JPError.m in Sources */,
 				30D61D6E23BB741A004E5CEE /* JPPaymentMethodsRouter.m in Sources */,
 				30D61D5823BB741A004E5CEE /* JPPaymentMethodsView.m in Sources */,
 				30221C9123FFC53600BF2823 /* JPCardPattern.m in Sources */,

--- a/Source/Extensions/JPError/JPError+Additions.h
+++ b/Source/Extensions/JPError/JPError+Additions.h
@@ -1,8 +1,8 @@
 //
-//  NSError+Additions.h
+//  JPError+Additions.h
 //  JudoKitObjC
 //
-//  Copyright (c) 2016 Alternative Payments Ltd
+//  Copyright (c) 2020 Alternative Payments Ltd
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
+#import "JPError.h"
 #import "JPCardNetwork.h"
 #import <Foundation/Foundation.h>
 
@@ -29,35 +30,35 @@
 
 extern NSString *_Nonnull const JudoErrorDomain;
 
-@interface NSError (Additions)
+@interface JPError (Additions)
 
-+ (nonnull NSError *)judoRequestFailedError;
-+ (nonnull NSError *)judoJSONSerializationFailedWithError:(nullable NSError *)error;
-+ (nonnull NSError *)judoJudoIdMissingError;
-+ (nonnull NSError *)judoPaymentMethodMissingError;
-+ (nonnull NSError *)judoAmountMissingError;
-+ (nonnull NSError *)judoReferenceMissingError;
-+ (nonnull NSError *)judoTokenMissingError;
-+ (nonnull NSError *)judoDuplicateTransactionError;
-+ (nonnull NSError *)judo3DSRequestFailedErrorWithUnderlyingError:(nullable NSError *)underlyingError;
-+ (nonnull NSError *)judoUserDidCancelError;
-+ (nonnull NSError *)judoParameterError;
-+ (nonnull NSError *)judoInternetConnectionError;
-+ (nonnull NSError *)judoJPApplePayConfigurationError;
-+ (nonnull NSError *)judoResponseParseError;
-+ (nonnull NSError *)judoMissingChecksumError;
-+ (nonnull NSError *)judoRequestTimeoutError;
-+ (nonnull NSError *)judoInvalidCardNumberError;
-+ (nonnull NSError *)judoUnsupportedCardNetwork:(CardNetwork)network;
-+ (nonnull NSError *)judoJailbrokenDeviceDisallowedError;
-+ (nonnull NSError *)judoInputMismatchErrorWithMessage:(nullable NSString *)message;
-+ (nonnull NSError *)judoErrorFromTransactionData:(nonnull JPTransactionData *)data;
-+ (nonnull NSError *)judoErrorFromDictionary:(nonnull NSDictionary *)dict;
-+ (nonnull NSError *)judoErrorFromError:(nonnull NSError *)error;
-+ (nonnull NSError *)judo3DSRequestWithPayload:(nonnull NSDictionary *)payload;
-+ (nonnull NSError *)judoInvalidIDEALCurrencyError;
-+ (nonnull NSError *)judoApplePayNotSupportedError;
-+ (nonnull NSError *)judoSiteIDMissingError;
++ (nonnull JPError *)judoRequestFailedError;
++ (nonnull JPError *)judoJSONSerializationFailedWithError:(nullable NSError *)error;
++ (nonnull JPError *)judoJudoIdMissingError;
++ (nonnull JPError *)judoPaymentMethodMissingError;
++ (nonnull JPError *)judoAmountMissingError;
++ (nonnull JPError *)judoReferenceMissingError;
++ (nonnull JPError *)judoTokenMissingError;
++ (nonnull JPError *)judoDuplicateTransactionError;
++ (nonnull JPError *)judo3DSRequestFailedErrorWithUnderlyingError:(nullable NSError *)underlyingError;
++ (nonnull JPError *)judoUserDidCancelError;
++ (nonnull JPError *)judoParameterError;
++ (nonnull JPError *)judoInternetConnectionError;
++ (nonnull JPError *)judoJPApplePayConfigurationError;
++ (nonnull JPError *)judoResponseParseError;
++ (nonnull JPError *)judoMissingChecksumError;
++ (nonnull JPError *)judoRequestTimeoutError;
++ (nonnull JPError *)judoInvalidCardNumberError;
++ (nonnull JPError *)judoUnsupportedCardNetwork:(CardNetwork)network;
++ (nonnull JPError *)judoJailbrokenDeviceDisallowedError;
++ (nonnull JPError *)judoInputMismatchErrorWithMessage:(nullable NSString *)message;
++ (nonnull JPError *)judoErrorFromTransactionData:(nonnull JPTransactionData *)data;
++ (nonnull JPError *)judoErrorFromDictionary:(nonnull NSDictionary *)dict;
++ (nonnull JPError *)judoErrorFromError:(nonnull NSError *)error;
++ (nonnull JPError *)judo3DSRequestWithPayload:(nonnull NSDictionary *)payload;
++ (nonnull JPError *)judoInvalidIDEALCurrencyError;
++ (nonnull JPError *)judoApplePayNotSupportedError;
++ (nonnull JPError *)judoSiteIDMissingError;
 
 @end
 

--- a/Source/Extensions/JPError/JPError+Additions.m
+++ b/Source/Extensions/JPError/JPError+Additions.m
@@ -1,5 +1,5 @@
 //
-//  NSError+Additions.m
+//  JPError+Additions.m
 //  JudoKitObjC
 //
 //  Copyright (c) 2016 Alternative Payments Ltd
@@ -24,7 +24,7 @@
 
 #import "JPCardNetwork.h"
 #import "JPTransactionData.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "NSString+Additions.h"
 
 NSString *const JudoErrorDomain = @"com.judo.error";
@@ -50,139 +50,139 @@ NSString *const ErrorInvalidIDEALCurrency = @"error_invalid_ideal_currency";
 NSString *const ErrorApplePayNotSupported = @"error_apple_pay_unsupported";
 NSString *const ErrorSiteIDMissing = @"error_site_id_missing";
 
-@implementation NSError (Additions)
+@implementation JPError (Additions)
 
-+ (NSError *)judoSiteIDMissingError {
++ (JPError *)judoSiteIDMissingError {
     NSDictionary *userInfo = [self userDataDictWithDescription:ErrorSiteIDMissing.localized
                                                  failureReason:nil
                                                          title:nil];
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorParameterError
                            userInfo:userInfo];
 }
 
-+ (NSError *)judoInvalidIDEALCurrencyError {
++ (JPError *)judoInvalidIDEALCurrencyError {
 
     NSDictionary *userInfo = [self userDataDictWithDescription:ErrorInvalidIDEALCurrency.localized
                                                  failureReason:nil
                                                          title:nil];
 
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorParameterError
                            userInfo:userInfo];
 }
 
-+ (NSError *)judoApplePayNotSupportedError {
++ (JPError *)judoApplePayNotSupportedError {
 
     NSDictionary *userInfo = [self userDataDictWithDescription:ErrorApplePayNotSupported.localized
                                                  failureReason:nil
                                                          title:nil];
 
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorGeneral_Error
                            userInfo:userInfo];
 }
 
-+ (NSError *)judoJailbrokenDeviceDisallowedError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoJailbrokenDeviceDisallowedError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorJailbrokenDeviceDisallowed
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorJailbrokenDeviceDisallowed.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoRequestFailedError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoRequestFailedError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorRequestFailed
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorRequestFailed.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoRequestTimeoutError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoRequestTimeoutError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorRequestFailed
                            userInfo:[self userDataDictWithDescription:@"error_timeout_description".localized
                                                         failureReason:@"error_timeout_description".localized
                                                                 title:@"error_timeout_title".localized]];
 }
 
-+ (NSError *)judoJSONSerializationFailedWithError:(nullable NSError *)error {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoJSONSerializationFailedWithError:(nullable JPError *)error {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorJSONSerializationFailed
                            userInfo:@{NSUnderlyingErrorKey : error}];
 }
 
-+ (NSError *)judoJudoIdMissingError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoJudoIdMissingError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorJudoIdMissing
                            userInfo:@{}];
 }
 
-+ (NSError *)judoAmountMissingError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoAmountMissingError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorAmountMissing
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorAmountMissing.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoPaymentMethodMissingError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoPaymentMethodMissingError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorPaymentMethodMissing
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorPaymentMethodMissing.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoReferenceMissingError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoReferenceMissingError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorReferenceMissing
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorReferenceMissing.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoTokenMissingError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoTokenMissingError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorTokenMissing
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorTokenMissing.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoDuplicateTransactionError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoDuplicateTransactionError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorDuplicateTransaction
                            userInfo:@{}];
 }
 
-+ (NSError *)judo3DSRequestFailedErrorWithUnderlyingError:(NSError *)underlyingError {
++ (JPError *)judo3DSRequestFailedErrorWithUnderlyingError:(JPError *)underlyingError {
     if (underlyingError) {
-        return [NSError errorWithDomain:JudoErrorDomain
+        return [JPError errorWithDomain:JudoErrorDomain
                                    code:JudoErrorFailed3DSRequest
                                userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                             failureReason:ErrorFailed3DSRequest.localized
                                                                     title:UnableToProcessRequestErrorTitle.localized
                                                               currentDict:@{NSUnderlyingErrorKey : underlyingError}]];
     }
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorFailed3DSRequest
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorFailed3DSRequest.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoErrorFromTransactionData:(JPTransactionData *)data {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoErrorFromTransactionData:(JPTransactionData *)data {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorTransactionDeclined
                            userInfo:data.rawData];
 }
 
-+ (NSError *)judoErrorFromDictionary:(NSDictionary *)dict {
++ (JPError *)judoErrorFromDictionary:(NSDictionary *)dict {
     NSString *messageFromDict = dict[@"message"];
     NSString *errorMessage = messageFromDict == nil ? UnableToProcessRequestErrorDesc.localized : messageFromDict;
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:[dict[@"code"] integerValue]
                            userInfo:[self userDataDictWithDescription:errorMessage
                                                         failureReason:nil
@@ -190,91 +190,91 @@ NSString *const ErrorSiteIDMissing = @"error_site_id_missing";
                                                           currentDict:dict]];
 }
 
-+ (NSError *)judoErrorFromError:(NSError *)error {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoErrorFromError:(JPError *)error {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorUnderlyingError
                            userInfo:@{NSUnderlyingErrorKey : error}];
 }
 
-+ (NSError *)judoUserDidCancelError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoUserDidCancelError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorUserDidCancel
                            userInfo:[self userDataDictWithDescription:nil
                                                         failureReason:ErrorUserDidCancel.localized
                                                                 title:nil]];
 }
 
-+ (NSError *)judoParameterError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoParameterError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorParameterError
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorParameterError.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoInternetConnectionError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoInternetConnectionError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorGeneral_Error
                            userInfo:[self userDataDictWithDescription:@"no_internet_error_description".localized
                                                         failureReason:@"no_internet_error_description".localized
                                                                 title:@"no_internet_error_title".localized]];
 }
 
-+ (NSError *)judoJPApplePayConfigurationError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoJPApplePayConfigurationError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorInvalidJPApplePayConfiguration
                            userInfo:@{NSLocalizedDescriptionKey : @"Invalid Apple Pay configuration"}];
 }
 
-+ (NSError *)judoInvalidCardNumberError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoInvalidCardNumberError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorInvalidCardNumberError
                            userInfo:@{NSLocalizedDescriptionKey : @"check_card_number".localized}];
 }
 
-+ (NSError *)judoUnsupportedCardNetwork:(CardNetwork)network {
++ (JPError *)judoUnsupportedCardNetwork:(CardNetwork)network {
 
     NSString *cardNetworkName = [JPCardNetwork nameOfCardNetwork:network];
     NSString *description = [NSString stringWithFormat:ErrorUnsupportedCardNetworkDescription.localized, cardNetworkName];
 
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorUnsupportedCardNetwork
                            userInfo:[self userDataDictWithDescription:description
                                                         failureReason:description
                                                                 title:ErrorUnsupportedCardNetworkTitle.localized]];
 }
 
-+ (NSError *)judoResponseParseError {
-    return [NSError errorWithDomain:JudoErrorDomain
++ (JPError *)judoResponseParseError {
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorResponseParseError
                            userInfo:[self userDataDictWithDescription:UnableToProcessRequestErrorDesc.localized
                                                         failureReason:ErrorResponseParseError.localized
                                                                 title:UnableToProcessRequestErrorTitle.localized]];
 }
 
-+ (NSError *)judoMissingChecksumError {
++ (JPError *)judoMissingChecksumError {
 
     NSDictionary *userInfo = [self userDataDictWithDescription:@"error_checksum_missing_description".localized
                                                  failureReason:@"error_checksum_missing_description".localized
                                                          title:@"error_checksum_missing_title".localized];
 
-    return [NSError errorWithDomain:JudoErrorDomain
+    return [JPError errorWithDomain:JudoErrorDomain
                                code:JudoErrorGeneral_Error
                            userInfo:userInfo];
 }
 
-+ (NSError *)judo3DSRequestWithPayload:(NSDictionary *)payload {
-    return [NSError errorWithDomain:JudoErrorDomain code:JudoError3DSRequest userInfo:payload];
++ (JPError *)judo3DSRequestWithPayload:(NSDictionary *)payload {
+    return [JPError errorWithDomain:JudoErrorDomain code:JudoError3DSRequest userInfo:payload];
 }
 
-+ (NSError *)judoInputMismatchErrorWithMessage:(NSString *)message {
++ (JPError *)judoInputMismatchErrorWithMessage:(NSString *)message {
     if (message) {
-        return [NSError errorWithDomain:JudoErrorDomain
+        return [JPError errorWithDomain:JudoErrorDomain
                                    code:JudoErrorInputMismatchError
                                userInfo:@{NSLocalizedDescriptionKey : message}];
     }
 
-    return [NSError errorWithDomain:JudoErrorDomain code:JudoErrorInputMismatchError userInfo:nil];
+    return [JPError errorWithDomain:JudoErrorDomain code:JudoErrorInputMismatchError userInfo:nil];
 }
 
 + (NSDictionary *)userDataDictWithDescription:(NSString *)description

--- a/Source/Extensions/NSString/NSString+Additions.m
+++ b/Source/Extensions/NSString/NSString+Additions.m
@@ -24,7 +24,7 @@
 
 #import "JPCardNetwork.h"
 #import "NSBundle+Additions.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "NSString+Additions.h"
 #import "UIFont+Additions.h"
 #import <Foundation/Foundation.h>

--- a/Source/JudoKit.h
+++ b/Source/JudoKit.h
@@ -108,25 +108,4 @@ static NSString *__nonnull const JudoKitVersion = @"8.2.1";
 - (void)invokePaymentMethodScreenWithMode:(TransactionMode)mode
                             configuration:(nonnull JPConfiguration *)configuration
                                completion:(nullable JudoCompletionBlock)completion;
-
-/**
- * A method which displays a list of all transactions of a specified type.
- *
- * @param type - an instance of TransactionType that describes the type of the transaction.
- * @param pagination - an instance of JPPagination in which pagination preferences are specified.
- * @param completion - a completion block with an optional JPResponse object or an NSError.
- */
-- (void)listTransactionsOfType:(TransactionType)type
-                     paginated:(nullable JPPagination *)pagination
-                    completion:(nullable JudoCompletionBlock)completion;
-
-/**
- * A method which returns a instance of JPReceipt based on a specified receipt ID.
- *
- * @param receiptId - an instance of NSString that serves as the receipt ID of a transaction.
- *
- * @returns - a configured instance of JPReceipt.
- */
-- (nonnull JPReceipt *)receiptForReceiptId:(nonnull NSString *)receiptId;
-
 @end

--- a/Source/JudoKitObjC.h
+++ b/Source/JudoKitObjC.h
@@ -72,4 +72,4 @@ FOUNDATION_EXPORT const unsigned char JudoKitObjCVersionString[];
 #import <JudoKitObjC/JPVCOResult.h>
 #import <JudoKitObjC/JPValidationResult.h>
 #import <JudoKitObjC/JudoKit.h>
-#import <JudoKitObjC/NSError+Additions.h>
+#import <JudoKitObjC/JPError+Additions.h>

--- a/Source/Models/Error/JPError.h
+++ b/Source/Models/Error/JPError.h
@@ -2,16 +2,29 @@
 //  JPError.h
 //  JudoKitObjC
 //
-//  Created by Mihai Petrenco on 5/4/20.
-//  Copyright © 2020 Judo Payments. All rights reserved.
+//  Copyright (c) 2020 Alternative Payments Ltd
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
 
 #import <Foundation/Foundation.h>
-
-NS_ASSUME_NONNULL_BEGIN
 
 @interface JPError : NSError
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Source/Models/Error/JPError.h
+++ b/Source/Models/Error/JPError.h
@@ -1,0 +1,17 @@
+//
+//  JPError.h
+//  JudoKitObjC
+//
+//  Created by Mihai Petrenco on 5/4/20.
+//  Copyright © 2020 Judo Payments. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface JPError : NSError
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Models/Error/JPError.m
+++ b/Source/Models/Error/JPError.m
@@ -2,9 +2,25 @@
 //  JPError.m
 //  JudoKitObjC
 //
-//  Created by Mihai Petrenco on 5/4/20.
-//  Copyright © 2020 Judo Payments. All rights reserved.
+//  Copyright (c) 2020 Alternative Payments Ltd
 //
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 #import "JPError.h"
 

--- a/Source/Models/Error/JPError.m
+++ b/Source/Models/Error/JPError.m
@@ -1,0 +1,13 @@
+//
+//  JPError.m
+//  JudoKitObjC
+//
+//  Created by Mihai Petrenco on 5/4/20.
+//  Copyright © 2020 Judo Payments. All rights reserved.
+//
+
+#import "JPError.h"
+
+@implementation JPError
+
+@end

--- a/Source/Models/Session/JPSession.h
+++ b/Source/Models/Session/JPSession.h
@@ -22,11 +22,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
+#import "JPError.h"
 #import <Foundation/Foundation.h>
 
 @class JPResponse;
 
-typedef void (^JudoCompletionBlock)(JPResponse *_Nullable, NSError *_Nullable);
+typedef void (^JudoCompletionBlock)(JPResponse *_Nullable, JPError *_Nullable);
 
 /**
  *  The Session class is a wrapper for all REST API calls

--- a/Source/Models/Session/JPSession.m
+++ b/Source/Models/Session/JPSession.m
@@ -29,7 +29,7 @@
 #import "JPResponse.h"
 #import "JPTransactionData.h"
 #import "JudoKit.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 
 #import <TrustKit/TrustKit.h>
 
@@ -135,7 +135,7 @@ static NSString *const kJudoSandboxBaseURL = @"https://api-sandbox.judopay.com/"
                             parameters:parameters
                             completion:completion];
     } else {
-        completion(nil, NSError.judoInternetConnectionError);
+        completion(nil, JPError.judoInternetConnectionError);
     }
 }
 
@@ -154,7 +154,7 @@ static NSString *const kJudoSandboxBaseURL = @"https://api-sandbox.judopay.com/"
                                                              error:&error];
         if (error) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                completion(nil, error);
+                completion(nil, (JPError *)error);
             });
             return;
         }
@@ -193,19 +193,19 @@ static NSString *const kJudoSandboxBaseURL = @"https://api-sandbox.judopay.com/"
                                                         delegateQueue:nil];
 
     return [urlSession dataTaskWithRequest:request
-                         completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
+                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                              if (!completion) {
                                  return;
                              }
 
                              if (error || !data) {
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                     completion(nil, error ? error : NSError.judoRequestFailedError);
+                                     completion(nil, error ? (JPError *)error : JPError.judoRequestFailedError);
                                  });
                                  return;
                              }
 
-                             __block NSError *jsonError = nil;
+                             __block JPError *jsonError = nil;
                              NSDictionary *responseJSON = [NSJSONSerialization JSONObjectWithData:data
                                                                                           options:NSJSONReadingAllowFragments
                                                                                             error:&jsonError];
@@ -213,7 +213,7 @@ static NSString *const kJudoSandboxBaseURL = @"https://api-sandbox.judopay.com/"
                              if (jsonError || !responseJSON) {
                                  dispatch_async(dispatch_get_main_queue(), ^{
                                      if (!jsonError) {
-                                         jsonError = [NSError judoJSONSerializationFailedWithError:jsonError];
+                                         jsonError = [JPError judoJSONSerializationFailedWithError:jsonError];
                                      }
                                      completion(nil, jsonError);
                                  });
@@ -222,14 +222,14 @@ static NSString *const kJudoSandboxBaseURL = @"https://api-sandbox.judopay.com/"
 
                              if (responseJSON[@"code"]) {
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                     completion(nil, [NSError judoErrorFromDictionary:responseJSON]);
+                                     completion(nil, [JPError judoErrorFromDictionary:responseJSON]);
                                  });
                                  return;
                              }
 
                              if (responseJSON[@"acsUrl"] && responseJSON[@"paReq"]) {
                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                     completion(nil, [NSError judo3DSRequestWithPayload:responseJSON]);
+                                     completion(nil, [JPError judo3DSRequestWithPayload:responseJSON]);
                                  });
                                  return;
                              }
@@ -252,7 +252,7 @@ static NSString *const kJudoSandboxBaseURL = @"https://api-sandbox.judopay.com/"
 
                              dispatch_async(dispatch_get_main_queue(), ^{
                                  if (result.items.count == 1 && responseJSON[@"result"] != nil && result.items.firstObject.result != TransactionResultSuccess) {
-                                     completion(nil, [NSError judoErrorFromTransactionData:result.items.firstObject]);
+                                     completion(nil, [JPError judoErrorFromTransactionData:result.items.firstObject]);
                                  } else {
                                      completion(result, nil);
                                  }

--- a/Source/Models/Transaction/JPTransaction.h
+++ b/Source/Models/Transaction/JPTransaction.h
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
+#import "JPSession.h"
+
 #import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
@@ -206,7 +208,7 @@ typedef NS_ENUM(NSUInteger, TransactionResult) {
  *
  * @param completion - the completion block that stores an optional JPResponse object or an NSError
  */
-- (void)sendWithCompletion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
+- (void)sendWithCompletion:(nonnull JudoCompletionBlock)completion;
 
 /**
  * A method that performs a 3D Secure transaction
@@ -217,22 +219,5 @@ typedef NS_ENUM(NSUInteger, TransactionResult) {
  */
 - (void)threeDSecureWithParameters:(nonnull NSDictionary *)parameters
                          receiptId:(nonnull NSString *)receiptId
-                        completion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
-
-/**
- * A method which returns a list of all transactions in a completion block
- *
- * @param completion - the completion block that stores an optional JPResponse object or an NSError
- */
-- (void)listWithCompletion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
-
-/**
- * A method which returns a list of all transactions in a completion block with specified pagination
- *
- * @param pagination - an object that describes the pagination logic (offset & page size) of the transaction list
- * @param completion - the completion block that stores an optional JPResponse object or an NSError
- */
-- (void)listWithPagination:(nullable JPPagination *)pagination
-                completion:(nonnull void (^)(JPResponse *_Nullable, NSError *_Nullable))completion;
-
+                        completion:(nonnull JudoCompletionBlock)completion;
 @end

--- a/Source/Models/Transaction/JPTransaction.m
+++ b/Source/Models/Transaction/JPTransaction.m
@@ -35,7 +35,7 @@
 #import "JPSession.h"
 #import "JPTransactionEnricher.h"
 #import "JPVCOResult.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 
 static NSString *const kPaymentPathKey = @"transactions/payments";
 static NSString *const kPreauthPathKey = @"transactions/preauths";
@@ -143,7 +143,7 @@ static NSString *const kRefundPathKey = @"/transactions/refunds";
         return;
     }
 
-    NSError *validationError = [self validateTransaction];
+    JPError *validationError = [self validateTransaction];
 
     if (validationError) {
         completion(nil, validationError);
@@ -163,7 +163,9 @@ static NSString *const kRefundPathKey = @"/transactions/refunds";
                       }];
 }
 
-- (void)threeDSecureWithParameters:(NSDictionary *)parameters receiptId:(NSString *)receiptId completion:(JudoCompletionBlock)completion {
+- (void)threeDSecureWithParameters:(NSDictionary *)parameters
+                         receiptId:(NSString *)receiptId
+                        completion:(JudoCompletionBlock)completion {
 
     NSString *fullURL = [NSString stringWithFormat:@"%@transactions/%@", self.apiSession.baseURL, receiptId];
 
@@ -187,24 +189,24 @@ static NSString *const kRefundPathKey = @"/transactions/refunds";
 
 #pragma mark - Helper methods
 
-- (NSError *)validateTransaction {
+- (JPError *)validateTransaction {
     if (!self.judoId) {
-        return [NSError judoJudoIdMissingError];
+        return JPError.judoJudoIdMissingError;
     }
 
     if (!self.card && !self.paymentToken && !self.pkPayment && !self.vcoResult) {
-        return [NSError judoPaymentMethodMissingError];
+        return JPError.judoPaymentMethodMissingError;
     }
 
     if (!self.reference) {
-        return [NSError judoReferenceMissingError];
+        return JPError.judoReferenceMissingError;
     }
 
     BOOL isRegisterCard = (self.transactionType == TransactionTypeRegisterCard);
     BOOL isCheckCard = (self.transactionType == TransactionTypeCheckCard);
     BOOL isSaveCard = (self.transactionType == TransactionTypeSaveCard);
     if (!isRegisterCard && !isCheckCard && !isSaveCard && !self.amount) {
-        return [NSError judoAmountMissingError];
+        return JPError.judoAmountMissingError;
     }
 
     return nil;

--- a/Source/Modules/3DSViewController/JP3DSViewController.m
+++ b/Source/Modules/3DSViewController/JP3DSViewController.m
@@ -22,9 +22,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
+#import "JPError.h"
 #import "JP3DSViewController.h"
 #import "JPLoadingView.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "UIColor+Additions.h"
 #import "UIView+Additions.h"
 
@@ -80,7 +81,7 @@
 
 - (void)onDismissTap {
     [self dismissViewControllerAnimated:YES completion:nil];
-    self.completionBlock(nil, NSError.judoUserDidCancelError);
+    self.completionBlock(nil, JPError.judoUserDidCancelError);
 }
 
 #pragma mark - Public methods
@@ -131,11 +132,11 @@
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-    self.completionBlock(nil, error);
+    self.completionBlock(nil, (JPError *)error);
 }
 
 - (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-    self.completionBlock(nil, error);
+    self.completionBlock(nil, (JPError *)error);
 }
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
@@ -189,7 +190,7 @@
     __weak typeof(self) weakSelf = self;
     [self.transaction threeDSecureWithParameters:response
                                        receiptId:self.configuration.receiptId
-                                      completion:^(JPResponse *response, NSError *error) {
+                                      completion:^(JPResponse *response, JPError *error) {
                                           if (error) {
                                               decisionHandler(WKNavigationActionPolicyCancel);
                                           } else {

--- a/Source/Modules/IDEALViewController/JPIDEALViewController.m
+++ b/Source/Modules/IDEALViewController/JPIDEALViewController.m
@@ -29,7 +29,7 @@
 #import "JPResponse.h"
 #import "JPTransactionData.h"
 #import "JPTransactionStatusView.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "UIView+Additions.h"
 
 @interface JPIDEALViewController ()
@@ -88,7 +88,7 @@ const float kPollingDelayTimer = 30.0;
 
     __weak typeof(self) weakSelf = self;
     [self.idealService redirectURLForIDEALBank:iDEALBank
-                                    completion:^(JPResponse *response, NSError *error) {
+                                    completion:^(JPResponse *response, JPError *error) {
                                         if (error) {
                                             [weakSelf dismissViewControllerAnimated:YES
                                                                          completion:^{
@@ -176,7 +176,7 @@ const float kPollingDelayTimer = 30.0;
             return;
         }
 
-        self.completionBlock(nil, NSError.judoMissingChecksumError);
+        self.completionBlock(nil, JPError.judoMissingChecksumError);
     }
 }
 
@@ -203,14 +203,14 @@ const float kPollingDelayTimer = 30.0;
 }
 
 - (void)handleError:(NSError *)error {
-    if (error.localizedDescription == NSError.judoRequestTimeoutError.localizedDescription) {
+    if (error.localizedDescription == JPError.judoRequestTimeoutError.localizedDescription) {
         [self.transactionStatusView changeToTransactionStatus:JPTransactionStatusTimeout];
-        self.completionBlock(self.redirectResponse, NSError.judoRequestTimeoutError);
+        self.completionBlock(self.redirectResponse, JPError.judoRequestTimeoutError);
         return;
     }
 
     [self dismissViewControllerAnimated:YES completion:nil];
-    self.completionBlock(self.redirectResponse, error);
+    self.completionBlock(self.redirectResponse, (JPError *)error);
     return;
 }
 
@@ -218,7 +218,7 @@ const float kPollingDelayTimer = 30.0;
     JPOrderDetails *orderDetails = response.items.firstObject.orderDetails;
     if (orderDetails && [orderDetails.orderFailureReason isEqualToString:kFailureReasonUserAbort]) {
         [self dismissViewControllerAnimated:YES completion:nil];
-        self.completionBlock(response, NSError.judoUserDidCancelError);
+        self.completionBlock(response, JPError.judoUserDidCancelError);
         return;
     }
 

--- a/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.m
+++ b/Source/Modules/PaymentMethods/Builder/JPPaymentMethodsBuilder.m
@@ -34,7 +34,7 @@
 #import "JPPaymentMethodsPresenter.h"
 #import "JPPaymentMethodsRouter.h"
 #import "JPPaymentMethodsViewController.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 
 #import "JPApplePayService.h"
 
@@ -56,12 +56,12 @@
         BOOL isApplePaySupported = [JPApplePayService isApplePaySupported];
 
         if (isIDEALPresent && isOnlyPaymentMethod && !isCurrencyEUR) {
-            completion(nil, NSError.judoInvalidIDEALCurrencyError);
+            completion(nil, JPError.judoInvalidIDEALCurrencyError);
             return nil;
         }
 
         if (isApplePayPresent && isOnlyPaymentMethod && !isApplePaySupported) {
-            completion(nil, NSError.judoApplePayNotSupportedError);
+            completion(nil, JPError.judoApplePayNotSupportedError);
             return nil;
         }
     }

--- a/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
+++ b/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
@@ -34,7 +34,7 @@
 #import "JPPaymentMethodsViewModel.h"
 #import "JPStoredCardDetails.h"
 #import "JPTransactionViewModel.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "NSString+Additions.h"
 
 @interface JPPaymentMethodsPresenterImpl ()

--- a/Source/Modules/PaymentMethods/Router/JPPaymentMethodsRouter.m
+++ b/Source/Modules/PaymentMethods/Router/JPPaymentMethodsRouter.m
@@ -22,6 +22,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
+#import "JPError.h"
 #import "JPPaymentMethodsRouter.h"
 #import "JPCardCustomizationBuilder.h"
 #import "JPCardCustomizationViewController.h"
@@ -30,7 +31,7 @@
 #import "JPTransactionBuilder.h"
 #import "JPTransactionService.h"
 #import "JPTransactionViewController.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 
 #import "JPConfiguration.h"
 #import "JPSliderTransitioningDelegate.h"
@@ -81,7 +82,7 @@
                         andCompletion:(JudoCompletionBlock)completion {
 
     if (!self.configuration.siteId) {
-        completion(nil, NSError.judoParameterError);
+        completion(nil, JPError.judoParameterError);
         return;
     }
 
@@ -111,7 +112,7 @@
 }
 
 - (void)completeTransactionWithResponse:(JPResponse *)response
-                               andError:(NSError *)error {
+                               andError:(JPError *)error {
     if (self.completionHandler)
         self.completionHandler(response, error);
 }

--- a/Source/Modules/Transaction/Interactor/JPTransactionInteractor.h
+++ b/Source/Modules/Transaction/Interactor/JPTransactionInteractor.h
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 
 #import "JPAddress.h"
+#import "JPError.h"
 #import "JPSession.h"
 #import "JPTransaction.h"
 #import "JPValidationResult.h"
@@ -75,10 +76,10 @@
  * A method for returning the transaction response / error to the merchant
  *
  * @param response - the JPResponse returned from the transaction
- * @param error - the NSError returned from the transaction
+ * @param error - the JPError returned from the transaction
  */
 - (void)completeTransactionWithResponse:(JPResponse *)response
-                                  error:(NSError *)error;
+                                  error:(JPError *)error;
 
 /**
  * A method for resetting the card validation results

--- a/Source/Modules/Transaction/Interactor/JPTransactionInteractor.m
+++ b/Source/Modules/Transaction/Interactor/JPTransactionInteractor.m
@@ -34,7 +34,7 @@
 #import "JPStoredCardDetails.h"
 #import "JPTransactionService.h"
 #import "JPTransactionViewModel.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "NSString+Additions.h"
 
 @interface JPTransactionInteractorImpl ()
@@ -112,7 +112,8 @@
     [transaction sendWithCompletion:completionHandler];
 }
 
-- (void)completeTransactionWithResponse:(JPResponse *)response error:(NSError *)error {
+- (void)completeTransactionWithResponse:(JPResponse *)response
+                                  error:(JPError *)error {
     if (self.completionHandler)
         self.completionHandler(response, error);
 }

--- a/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
+++ b/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
@@ -26,7 +26,7 @@
 #import "JPTransactionInteractor.h"
 #import "JPTransactionRouter.h"
 #import "JPTransactionViewController.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 
 #import "JPAddress.h"
 #import "JPCard.h"
@@ -122,7 +122,7 @@
 
     __weak typeof(self) weakSelf = self;
     [self.interactor sendTransactionWithCard:card
-                           completionHandler:^(JPResponse *response, NSError *error) {
+                           completionHandler:^(JPResponse *response, JPError *error) {
                                if (error) {
                                    [weakSelf handleError:error];
                                    return;
@@ -132,7 +132,7 @@
                            }];
 }
 
-- (void)handleError:(NSError *)error {
+- (void)handleError:(JPError *)error {
     if (error.code == JudoError3DSRequest) {
         [self handle3DSecureTransactionFromError:error];
         return;
@@ -144,7 +144,7 @@
 - (void)handle3DSecureTransactionFromError:(NSError *)error {
     __weak typeof(self) weakSelf = self;
     [self.interactor handle3DSecureTransactionFromError:error
-                                             completion:^(JPResponse *response, NSError *error) {
+                                             completion:^(JPResponse *response, JPError *error) {
                                                  if (error) {
                                                      [weakSelf handleError:error];
                                                      return;
@@ -160,7 +160,7 @@
         NSString *token = response.items.firstObject.cardDetails.cardToken;
 
         if (!token) {
-            [self.view updateViewWithError:NSError.judoTokenMissingError];
+            [self.view updateViewWithError:JPError.judoTokenMissingError];
             return;
         }
 

--- a/Source/Services/ApplePay/JPApplePayService.m
+++ b/Source/Services/ApplePay/JPApplePayService.m
@@ -31,7 +31,7 @@
 #import "JPReference.h"
 #import "JPResponse.h"
 #import "JPTransactionData.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "UIApplication+Additions.h"
 
 @interface JPApplePayService ()
@@ -95,7 +95,7 @@
     [transaction setPkPayment:payment error:&error];
 
     if (error && self.completionBlock) {
-        self.completionBlock(nil, [NSError judoJSONSerializationFailedWithError:error]);
+        self.completionBlock(nil, [JPError judoJSONSerializationFailedWithError:error]);
         completion(PKPaymentAuthorizationStatusFailure);
         return;
     }
@@ -104,7 +104,7 @@
     [transaction sendWithCompletion:^(JPResponse *response, NSError *error) {
         if (error || response.items.count == 0) {
             if (weakSelf.completionBlock)
-                weakSelf.completionBlock(response, error);
+                weakSelf.completionBlock(response, (JPError *)error);
             completion(PKPaymentAuthorizationStatusFailure);
             return;
         }
@@ -118,7 +118,7 @@
         }
 
         if (weakSelf.completionBlock)
-            weakSelf.completionBlock(response, error);
+            weakSelf.completionBlock(response, (JPError *)error);
         completion(PKPaymentAuthorizationStatusSuccess);
     }];
 }

--- a/Source/Services/CardValidation/JPCardValidationService.m
+++ b/Source/Services/CardValidation/JPCardValidationService.m
@@ -27,7 +27,7 @@
 #import "JPCardNetwork.h"
 #import "JPConstants.h"
 #import "JPValidationResult.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 #import "NSString+Additions.h"
 
 @interface JPCardValidationService ()
@@ -76,11 +76,11 @@ static int const kCardHolderNameLength = 3;
     }
 
     if ((cardNumber.length == maxCardLength) && (![cardNumber isCardNumberValid])) {
-        error = NSError.judoInvalidCardNumberError;
+        error = JPError.judoInvalidCardNumberError;
     }
 
     if (![self isInputSupported:cardNumber forSupportedNetworks:networks]) {
-        error = [NSError judoUnsupportedCardNetwork:input.cardNetwork];
+        error = [JPError judoUnsupportedCardNetwork:input.cardNetwork];
     }
 
     cardNumber = [cardNumber formatWithPattern:cardNetworkPatern];

--- a/Source/Services/ConfigurationValidation/JPConfigurationValidationService.h
+++ b/Source/Services/ConfigurationValidation/JPConfigurationValidationService.h
@@ -22,28 +22,41 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-#import "JPAmount.h"
 #import "JPConfiguration.h"
-#import "JPConstants.h"
-#import "JPReference.h"
-#import "JPSession.h"
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, JPValidationType) {
-    JPValidationTypeTransaction,
-    JPValidationTypeApplePay
+typedef NS_ENUM(NSUInteger, JPValidationError) {
+    JPValidationErrorMissingParameter,
+    JPValidationErrorInvalidParameter
 };
 
 @protocol JPConfigurationValidationService
-@required
-- (BOOL)isTransactionValidWithConfiguration:(JPConfiguration *)configuration
-                             validationType:(JPValidationType)validationType
-                            transactionType:(TransactionType)transactionType
-                                 completion:(JudoCompletionBlock)completion;
+
+/**
+ * A method that validates the configuration and returns an optional JPError if the configuration fails
+ *
+ * @param configuration - an instance of JPConfiguration that contains all the payment configuration properties
+ * @param transactionType - the transaction type used to apply the correct validation rules
+ *
+ * @returns an optional instance of JPError containing the validation error details
+ */
+- (JPError *)validateConfiguration:(JPConfiguration *)configuration
+                forTransactionType:(TransactionType)transactionType;
+
+/**
+ * A method that validates the Apple Pay configuration and returns an optional JPError if the configuration fails
+ *
+ * @param configuration - an instance of JPConfiguration that contains all the payment configuration properties
+ *
+ * @returns an optional instance of JPError containing the validation error details
+ */
+- (JPError *)valiadateApplePayConfiguration:(JPConfiguration *)configuration;
+
 @end
 
 /**
- * A class that handles JPConfiguration validation
+ * A class that implements the JPConfigurationValidationService protocol
  */
 @interface JPConfigurationValidationServiceImp : NSObject <JPConfigurationValidationService>
+
 @end

--- a/Source/Services/Transaction/JPTransactionService.h
+++ b/Source/Services/Transaction/JPTransactionService.h
@@ -78,24 +78,4 @@ typedef NS_ENUM(NSUInteger, HTTPMethod) {
                      parameters:(nullable NSDictionary *)parameters
                      completion:(nullable JudoCompletionBlock)completion;
 
-/**
- * A method which returns a list of transactions based on a specified type.
- *
- * @param type - the type of the transaction.
- * @param pagination - an instance of JPPagination which offers pagination details
- * @param completion - a completion block with an optinal JPResponse or NSError
- */
-- (void)listTransactionsOfType:(TransactionType)type
-                     paginated:(nullable JPPagination *)pagination
-                    completion:(nullable JudoCompletionBlock)completion;
-
-/**
- * A method which returns a instance of JPReceipt based on a specified receipt ID.
- *
- * @param receiptId - an instance of NSString that serves as the receipt ID of a transaction.
- *
- * @returns - a configured instance of JPReceipt.
- */
-- (nonnull JPReceipt *)receiptForReceiptId:(nonnull NSString *)receiptId;
-
 @end

--- a/Source/Services/Transaction/JPTransactionService.m
+++ b/Source/Services/Transaction/JPTransactionService.m
@@ -27,7 +27,6 @@
 #import "JPCard.h"
 #import "JPReference.h"
 #import "JPTransactionEnricher.h"
-#import "NSError+Additions.h"
 
 @interface JPTransactionService ()
 @property (nonatomic, strong) JPSession *session;
@@ -70,26 +69,11 @@
 
 - (JPTransaction *)transactionWithConfiguration:(JPConfiguration *)configuration {
 
-    if (configuration.receiptId) {
-        return [self receiptTransactionWithConfiguration:configuration];
-    }
-
     JPTransaction *transaction = [JPTransaction transactionWithType:self.transactionType];
     transaction.judoId = configuration.judoId;
     transaction.amount = [self amountForTransactionType:configuration];
     transaction.reference = configuration.reference;
     transaction.primaryAccountDetails = configuration.primaryAccountDetails;
-    transaction.apiSession = self.session;
-    transaction.enricher = self.enricher;
-
-    return transaction;
-}
-
-- (JPTransaction *)receiptTransactionWithConfiguration:(JPConfiguration *)configuration {
-
-    JPTransaction *transaction = [JPTransaction transactionWithType:self.transactionType
-                                                          receiptId:configuration.receiptId
-                                                             amount:configuration.amount];
     transaction.apiSession = self.session;
     transaction.enricher = self.enricher;
 
@@ -107,21 +91,6 @@
         default:
             return configuration.amount;
     }
-}
-
-- (JPReceipt *)receiptForReceiptId:(NSString *)receiptId {
-    JPReceipt *receipt = [[JPReceipt alloc] initWithReceiptId:receiptId];
-    receipt.apiSession = self.session;
-    return receipt;
-}
-
-- (void)listTransactionsOfType:(TransactionType)type
-                     paginated:(JPPagination *)pagination
-                    completion:(JudoCompletionBlock)completion {
-
-    JPTransaction *transaction = [JPTransaction transactionWithType:type];
-    transaction.apiSession = self.session;
-    [transaction listWithPagination:pagination completion:completion];
 }
 
 - (void)sendRequestWithEndpoint:(NSString *)endpoint

--- a/Source/Services/iDEAL/JPIDEALService.m
+++ b/Source/Services/iDEAL/JPIDEALService.m
@@ -28,7 +28,7 @@
 #import "JPReference.h"
 #import "JPResponse.h"
 #import "JPTransactionData.h"
-#import "NSError+Additions.h"
+#import "JPError+Additions.h"
 
 @interface JPIDEALService ()
 @property (nonatomic, strong) JPConfiguration *configuration;
@@ -68,7 +68,7 @@ static const float kTimerDuration = 60.0f;
     NSDictionary *parameters = [self parametersForIDEALBank:iDealBank];
 
     if (!parameters) {
-        completion(nil, NSError.judoSiteIDMissingError);
+        completion(nil, JPError.judoSiteIDMissingError);
         return;
     }
 
@@ -80,11 +80,11 @@ static const float kTimerDuration = 60.0f;
                                               JPTransactionData *data = response.items.firstObject;
 
                                               if (data.orderDetails.orderId && data.redirectUrl) {
-                                                  completion([weakSelf remapIdealResponseWithResponse:response], error);
+                                                  completion([weakSelf remapIdealResponseWithResponse:response], (JPError *)error);
                                                   return;
                                               }
 
-                                              completion(nil, NSError.judoResponseParseError);
+                                              completion(nil, JPError.judoResponseParseError);
                                           }];
 }
 
@@ -97,10 +97,12 @@ static const float kTimerDuration = 60.0f;
                                                  repeats:NO
                                                    block:^(NSTimer *_Nonnull timer) {
                                                        weakSelf.didTimeout = true;
-                                                       completion(nil, NSError.judoRequestTimeoutError);
+                                                       completion(nil, JPError.judoRequestTimeoutError);
                                                        return;
                                                    }];
-    [self getStatusForOrderId:orderId checksum:checksum completion:completion];
+    
+    [self getStatusForOrderId:orderId checksum:checksum
+                   completion:completion];
 }
 
 - (void)getStatusForOrderId:(NSString *)orderId
@@ -118,8 +120,9 @@ static const float kTimerDuration = 60.0f;
                                           httpMethod:HTTPMethodGET
                                           parameters:nil
                                           completion:^(JPResponse *response, NSError *error) {
+        
                                               if (error) {
-                                                  completion(nil, error);
+                                                  completion(nil, (JPError *)error);
                                                   [weakSelf.timer invalidate];
                                                   return;
                                               }
@@ -131,8 +134,9 @@ static const float kTimerDuration = 60.0f;
                                                   });
                                                   return;
                                               }
+        
                                               JPResponse *mappedResponse = [weakSelf remapIdealResponseWithResponse:response];
-                                              completion(mappedResponse, error);
+                                              completion(mappedResponse, nil);
                                               [weakSelf.timer invalidate];
                                           }];
 }


### PR DESCRIPTION
# Changelog:
- Removed `list` and `receipt` transactions from the Judo SDK;
- Simplified the `JudoConfigurationValidation` implementation;
- Replaced the `NSError` references to the custom `JPError` object;

## Notes:
I added a `TODO` comment that hopefully is going to be fixed soon. There is no validation for the Payment Method screen.